### PR TITLE
Zero-copy nested lists via inline MORL regions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-mori — Shared Memory for R Objects. Uses POSIX shared memory (Linux, macOS) and Win32 file mappings (Windows) with R's ALTREP framework to let multiple processes on the same machine read the same physical memory pages. No external dependencies. Requires R >= 4.3.0 (for ALTLIST). API: `share()` → ALTREP shared object, `map_shared()` → open SHM by name, `shared_name()` → extract SHM name, `is_shared()` → test if shared. SHM lifetime is automatic — managed by R's garbage collector via chained external pointer finalizers. ALTREP serialization hooks serialize standalone shared objects as the SHM name (~30 bytes) and ALTLIST element vectors as `(parent_name, index)`, enabling transparent use with mirai and any R serialization path.
+mori — Shared Memory for R Objects. Uses POSIX shared memory (Linux, macOS) and Win32 file mappings (Windows) with R's ALTREP framework to let multiple processes on the same machine read the same physical memory pages. No external dependencies. Requires R >= 4.3.0 (for ALTLIST). API: `share()` → ALTREP shared object, `map_shared()` → open SHM by name, `shared_name()` → extract SHM name, `is_shared()` → test if shared. SHM lifetime is automatic — managed by R's garbage collector via chained external pointer finalizers. ALTREP serialization hooks serialize standalone shared objects as the SHM name (~30 bytes) and nested ALTLIST elements (including sub-lists) as `(parent_name, integer_path)`, enabling transparent use with mirai and any R serialization path. Nested VECSXP elements are zero-copy: each level is an inline self-describing MORL region inside the parent SHM.
 
 ## Development Commands
 
@@ -14,8 +14,6 @@ mori — Shared Memory for R Objects. Uses POSIX shared memory (Linux, macOS) an
 # Run the full testthat suite
 devtools::test()
 ```
-
-Set `NOT_CRAN=true` environment variable to run integration tests that require mirai daemons.
 
 ### Building and Checking
 
@@ -37,6 +35,7 @@ devtools::document()
 ### Storage Model
 
 - **Zero-copy (SHM-backed)**: All atomic vectors (including character vectors and those with arbitrary attributes such as names, class, levels, dim) and data frame columns are written directly into SHM and backed by ALTREP on consumers. Attributes are serialized into a trailing section of the SHM region and restored via `SET_ATTRIB` on the consumer. For numeric types, `Dataptr_or_null` returns the SHM pointer for reads; `Dataptr(writable=TRUE)` materializes a private copy (COW). For character vectors, `Elt` lazily creates each CHARSXP via `Rf_mkCharLenCE` from the SHM data; `Dataptr_or_null` returns NULL to force element-by-element access.
+- **Nested lists (zero-copy)**: VECSXP/LISTSXP elements of a shared list are written inline as a complete child MORL region at their `data_offset`. Each nested region is self-describing (magic bytes + header) and recursively contains its own directory, element data, and attributes. Consumers wrap each level in its own ALTLIST via a lightweight `mori_list_view` (pointer + bounds + index) rather than a full `mori_shm`. Sub-lists therefore stay zero-copy all the way down and report `is_shared(x) == TRUE`; `shared_name()` returns the root SHM name for root lists and `""` for sub-lists.
 - **Pass-through**: All other R objects (environments, closures, language objects) are returned unchanged by `share()`. No SHM is created.
 
 ### share() Dispatch Logic (altrep.c: `mori_create`)
@@ -44,7 +43,7 @@ devtools::document()
 All R exported functions are single `.Call` wrappers. `share()` calls `mori_create` which dispatches on `TYPEOF(x)`:
 
 1. `NILSXP` → returned as-is (falls through all checks).
-2. `VECSXP`/`LISTSXP` → `mori_shm_create_list_call` — ALTLIST with per-element directory. Each element is independently zero-copy (any atomic, with or without attributes) or serialized as bytes. Data frames and pairlists go through this path (pairlists are coerced to VECSXP via `Rf_coerceVector` at the C level).
+2. `VECSXP`/`LISTSXP` → `mori_shm_create_list_call` — ALTLIST with per-element directory. Writing is split into two passes: `mori_nested_size` computes the total SHM size (recursing into nested VECSXP/LISTSXP elements), and `mori_nested_write` produces a complete MORL region at the target base pointer, recursing into child VECSXP/LISTSXP elements by calling itself on `base + child_data_offset`. Each element is independently zero-copy (any atomic, with or without attributes), serialized as bytes, or a nested MORL region. Data frames and pairlists go through this path (pairlists are coerced to VECSXP via `Rf_coerceVector`, both at the top level and at each level of the recursion).
 3. `STRSXP` → `mori_shm_create_string_call` — ALTSTRING backed by SHM with offset table + packed string data. Attributes (if any) are serialized after the string data.
 4. Other SHM-eligible types (`REALSXP`, `INTSXP`, `LGLSXP`, `RAWSXP`, `CPLXSXP`) → `mori_shm_create_vector_call` — single ALTREP vector backed by SHM. Attributes (if any) are serialized after the vector data.
 5. Everything else → returned as-is (pass-through).
@@ -56,7 +55,7 @@ Each creation path returns the ALTREP result via `mori_make_result`, which chain
 All ALTREP classes register `Serialized_state` and `Unserialize` methods.
 
 - **Standalone shared objects** (created by `share()` or `map_shared()`) serialize as just the SHM name string (~30 bytes). On unserialize, `mori_Unserialize` validates the name via `mori_is_shm_name()` (checks `/mori_` prefix on POSIX, `Local\mori_` on Windows), then `mori_shm_open_and_wrap` opens the SHM and creates a fresh ALTREP wrapper. R's ALTREP serialization framework separately serializes and restores the object's attributes.
-- **Element vectors from ALTLIST** serialize as `list(parent_name, index)`. On unserialize, `mori_Unserialize` validates element types (first element is STRSXP, second is INTSXP) before treating as an element reference, then `mori_open_element` opens the parent SHM and extracts the element by index (including restoring per-element attributes from the directory's `attrs_size` field). The element's `mori_vec`/`mori_str` struct stores an `index` field (int32_t, -1 for standalone, >= 0 for ALTLIST elements).
+- **Element vectors and sub-lists from ALTLIST** serialize as `list(parent_name, int_path)` where `int_path` is an INTSXP of length >= 1 giving top-down indices from the root region to the leaf. Length 1 is wire-identical to the previous scalar `(name, index)` form, so existing serialized blobs remain readable. On unserialize, `mori_Unserialize` validates element types (first element is STRSXP, second is INTSXP of length >= 1) and that the name looks like a mori SHM name before calling `mori_open_path`, which opens the root SHM, walks each intermediate VECSXP directory entry via `mori_make_list_view` (bounds-checking the child region against its parent), and finally calls `mori_unwrap_element` at the leaf. The element's `mori_vec`/`mori_str` struct stores an `index` field (int32_t, -1 for standalone, >= 0 for ALTLIST elements), and each `mori_list_view` likewise stores an `index` (-1 for a root view, >= 0 for a sub-list) — these indices are what `mori_build_path` collects while walking the keeper chain up through view extptrs at serialize time.
 
 Fallback to full materialization when:
 - COW-materialized vectors (data2 is set)
@@ -97,7 +96,7 @@ All attributes (names, dim, class, levels, tzone, etc.) are serialized as a pair
 | varies | | element data (64-byte aligned) |
 | varies | | serialized attributes (names, class, row.names) |
 
-Each element directory entry (32 bytes): `data_offset(8) + data_size(8) + sexptype(4) + attrs_size(4) + length(8)`. `sexptype != 0` means zero-copy (raw data or string); `sexptype == 0` means serialized bytes. `sexptype == STRSXP` indicates a string element whose data region contains an offset table + packed strings. When `attrs_size > 0`, the element's serialized attributes are appended after the raw data within the data region (at offset `data_offset + data_size - attrs_size`). On the consumer, `mori_restore_attrs` unserializes and applies them.
+Each element directory entry (32 bytes): `data_offset(8) + data_size(8) + sexptype(4) + attrs_size(4) + length(8)`. `sexptype != 0` means zero-copy (raw data, string, or nested list); `sexptype == 0` means serialized bytes. `sexptype == STRSXP` indicates a string element whose data region contains an offset table + packed strings. `sexptype == VECSXP` indicates a nested MORL region inline at `data_offset` of size `data_size` (the child's own header, directory, elements, and attrs all live inside that region); the parent directory entry's `attrs_size` is always 0 for VECSXP children — any attributes are part of the child region's own trailing attrs. For non-nested zero-copy entries with `attrs_size > 0`, the element's serialized attributes are appended after the raw data within the data region (at offset `data_offset + data_size - attrs_size`). On the consumer, `mori_restore_attrs` unserializes and applies them.
 
 **String vector (MORS):** 24-byte header + offset table + packed string data + optional serialized attributes.
 
@@ -127,24 +126,26 @@ Each offset table entry (16 bytes): `str_offset(int64) + str_length(int32) + str
 
 ## Internal State
 
-- **`mori_tag`** (C global, `altrep.c`): Interned symbol `Rf_install("mori")`. Serves two roles: (1) tag on every SHM extptr for `is_shared()` identification, (2) ALTLIST cache sentinel to distinguish "not yet accessed" from a cached `NULL` element.
+- **`mori_tag`** (C global, `altrep.c`): Interned symbol `Rf_install("mori")`. Role: ALTLIST cache sentinel only — distinguishes "not yet accessed" from a cached `NULL` element.
+- **`mori_shm_tag`** (C global, `altrep.c`): Interned symbol `Rf_install("mori_shm")`. Tag on every SHM extptr; addr is a `mori_shm *`.
+- **`mori_view_tag`** (C global, `altrep.c`): Interned symbol `Rf_install("mori_view")`. Tag on every list view extptr; addr is a `mori_list_view *`. The two distinct tags disambiguate the extptr's addr type without inspecting struct internals and let `is_shared()` and `mori_shm_name` stay O(1). `is_shared()` accepts either tag (list data1 is tagged `view`; vec/str data1's prot is tagged either `view` for elements or `shm` for standalone).
 
 ### GC and Lifetime
 
 SHM lifetime is fully automatic, managed by chaining the host extptr (responsible for `shm_unlink`/`CloseHandle`) into the ALTREP object's external pointer hierarchy.
 
 - **Host side (`share`)**: `mori_shm_create` allocates the SHM region and mmaps it; on POSIX, the fd is closed immediately after mmap (the mapping stays valid; the `mori_shm` struct does not retain the fd). `mori_make_result` splits ownership: the ALTREP wrapper gets the mapping (`addr`, `size`) via the daemon-side SHM extptr (`mori_shm_finalizer` → munmap), and the host extptr gets the handle (`name` for POSIX unlink, `HANDLE` for Windows) via `mori_host_finalizer`. The host extptr is chained as the protected value of the ALTREP's SHM extptr. When the ALTREP is garbage collected, both finalizers run: munmap + unlink. `R_RegisterCFinalizerEx(..., TRUE)` ensures cleanup on session exit.
-- **Consumer side (`map_shared`/unserialize)**: `mori_shm_open` maps the region read-only (size discovered via `fstat`/`VirtualQuery`); on POSIX, the fd is closed immediately after mmap. Each ALTREP wrapper holds an external pointer (`mori_shm_finalizer`) that calls `munmap` (never unlink). ALTLIST element vectors hold a `mori_vec` or `mori_str` extptr whose protected value references the parent SHM extptr, keeping the mapping alive. Element vectors store their index (`int32_t`) in the `mori_vec`/`mori_str` struct for compact serialization.
-- **Element lifetime**: Element vectors extracted from an ALTLIST keep the parent SHM alive through the extptr chain (element → parent SHM extptr → host extptr). Even if the parent ALTLIST is garbage collected, the SHM survives as long as any element is referenced.
+- **Consumer side (`map_shared`/unserialize)**: `mori_shm_open` maps the region read-only (size discovered via `fstat`/`VirtualQuery`); on POSIX, the fd is closed immediately after mmap. The shm extptr (tag `mori_shm_tag`) holds the `mori_shm *` and its `mori_shm_finalizer` calls `munmap` (never unlink). For lists, the shm extptr's immediate child is a root view extptr (tag `mori_view_tag`, addr `mori_list_view *`, index=-1) that becomes ALTREP data1; sub-list views (index >= 0) chain through their parent view extptr in the same way. ALTLIST element vectors hold a `mori_vec` or `mori_str` extptr whose protected value references the immediate parent view extptr (or the shm extptr, for vec/str at the root of the MORH/MORS regions).
+- **Element lifetime**: Element vectors and sub-lists extracted from an ALTLIST keep the root SHM alive through the keeper chain (leaf element → parent view(s) → root shm extptr → host extptr). Even if the enclosing ALTLIST(s) are garbage collected, every `R_MakeExternalPtr(addr, tag, prot)` keeps its `prot` slot alive, so the chain survives as long as any descendant is referenced. `mori_build_path` walks this chain at serialize time, collecting view indices (skipping the root view's -1) until it reaches the shm extptr and reads the name.
 
 ## Code Organization
 
 ### src/ Directory
 
-- **mori.h**: Types (`mori_shm`, `mori_buf`, `mori_vec` with `index` field), function declarations, `MORI_ALIGN64` macro
+- **mori.h**: Types (`mori_shm`, `mori_buf`, `mori_vec` with `index` field, `mori_list_view`), function declarations, `MORI_ALIGN64` macro
 - **shm.c**: Platform-abstracted SHM create/open/close. On Linux, uses `open("/dev/shm/...")` directly to avoid `-lrt` link dependency. On macOS, uses `shm_open`/`shm_unlink` (in libc). Finalizers for both host and daemon side.
 - **serialize.c**: Counting pass (`mori_serialize_count`), fixed-buffer write (`mori_serialize_into`), unserialize-from-buffer (`mori_unserialize_from`), `mori_sizeof_elt`
-- **altrep.c**: All ALTREP class definitions and methods, `mori_make_vector`/`mori_make_string` helpers, `mori_unwrap_element` helper (shared element extraction for `mori_list_Elt` and `mori_open_element`), `mori_restore_attrs` helper, `mori_is_shm_name` validator, unified creation dispatcher (`mori_create`), static per-type creation functions, consumer-side open+wrap dispatch (`mori_shm_open_and_wrap`), element open (`mori_open_element`), identity check (`mori_is_shared`), name extraction (`mori_shm_name`), serialization hooks (`Serialized_state`/`Unserialize`), `mori_altrep_init`
+- **altrep.c**: All ALTREP class definitions and methods, `mori_make_vector`/`mori_make_string`/`mori_make_list_view` helpers, `mori_unwrap_element` helper (shared element extraction for `mori_list_Elt` and `mori_open_path`; validates dir bounds against the enclosing region), `mori_restore_attrs` helper, `mori_is_shm_name` validator, unified creation dispatcher (`mori_create`), recursive writer helpers `mori_nested_size` / `mori_nested_write`, consumer-side open+wrap dispatch (`mori_shm_open_and_wrap`), path open (`mori_open_path`), identity check (`mori_is_shared`), name extraction (`mori_shm_name`), serialization hooks (`Serialized_state`/`Unserialize`), `mori_build_path` (keeper-chain walker), `mori_altrep_init`
 - **init.c**: `R_init_mori`, `.Call` registration table (4 entry points: `mori_create`, `mori_shm_open_and_wrap`, `mori_is_shared`, `mori_shm_name`)
 
 `.Call` names match their C function names. All entry points take a single `SEXP` argument.
@@ -162,13 +163,14 @@ Uses **testthat** (edition 3). The entry point is `tests/testthat.R`; individual
 - `test-vectors.R` — atomic vector round-trip (double, integer, logical, raw, complex, matrix, empty)
 - `test-strings.R` — ALTSTRING behaviour (basic, NA, empty, UTF-8, large, data frame column, list element, `Dataptr` materialization via `make.unique`/`duplicated`)
 - `test-list.R` — ALTLIST (data frames, mixed lists, NULL elements, duplicate, pairlist)
+- `test-nested.R` — nested VECSXP elements (sub-lists, list-columns, deep structures, path-based serialization, sub-list COW, GC with nested references)
 - `test-attributes.R` — attribute preservation (names, factor, Date, POSIXct, matrix)
 - `test-cow.R` — copy-on-write for numeric and string vectors, `Dataptr_or_null` on materialized vec
 - `test-serialization.R` — ALTREP `Serialized_state`/`Unserialize` hooks (standalone, element, compact size, COW fallback, attributes)
 - `test-gc.R` — automatic SHM cleanup by garbage collector
 - `test-api.R` — `share()`/`map_shared()`/`shared_name()`/`is_shared()` behaviour including invalid inputs
 
-Integration tests (with mirai daemons) are gated behind `NOT_CRAN=true`.
+All tests run unconditionally; nothing is gated behind `skip_on_cran` or environment variables.
 
 ## Platform Notes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # mori (development version)
 
+* Nested list elements are now zero-copy.
 * Package renamed from `sora` to `mori`.
 * `sora()` had been renamed to `share()`.
 

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -59,7 +59,7 @@ static inline SEXP mori_get_attrs_for_serialize(SEXP x) {
 /* Sets class last to avoid validation ordering issues. */
 static void mori_set_attrs_from(SEXP result, SEXP attrs) {
 #if R_VERSION >= R_Version(4, 6, 0)
-  SEXP names = Rf_getAttrib(attrs, R_NamesSymbol);
+  SEXP names = PROTECT(Rf_getAttrib(attrs, R_NamesSymbol));
   R_xlen_t n = XLENGTH(attrs), class_idx = -1;
   for (R_xlen_t i = 0; i < n; i++) {
     SEXP nm = Rf_installChar(STRING_ELT(names, i));
@@ -68,6 +68,7 @@ static void mori_set_attrs_from(SEXP result, SEXP attrs) {
   }
   if (class_idx >= 0)
     Rf_classgets(result, VECTOR_ELT(attrs, class_idx));
+  UNPROTECT(1);
 #else
   SET_ATTRIB(result, attrs);
   if (Rf_getAttrib(result, R_ClassSymbol) != R_NilValue)
@@ -1158,13 +1159,15 @@ static SEXP mori_open_path(SEXP name, SEXP path_sxp) {
   const int *path = INTEGER(path_sxp);
 
   SEXP keeper = shm_ptr;
-  int nprotect = 1;
   unsigned char *cur_base = base;
   int64_t cur_region_size = (int64_t) shm_stack.size;
   int32_t cur_n;
   memcpy(&cur_n, cur_base + 4, 4);
 
-  /* Walk intermediate VECSXP levels */
+  PROTECT_INDEX child_idx;
+  SEXP child = R_NilValue;
+  PROTECT_WITH_INDEX(child, &child_idx);
+
   for (int k = 0; k < path_len - 1; k++) {
     int idx = path[k];
     if (idx < 0 || idx >= cur_n)
@@ -1183,10 +1186,9 @@ static SEXP mori_open_path(SEXP name, SEXP path_sxp) {
         data_offset + data_size > cur_region_size)
       Rf_error("mori:nested region out of bounds");
 
-    SEXP child = PROTECT(mori_make_list_view(
+    REPROTECT(child = mori_make_list_view(
       cur_base + data_offset, data_size, idx, keeper
-    ));
-    nprotect++;
+    ), child_idx);
     keeper = R_altrep_data1(child);
 
     cur_base = cur_base + data_offset;
@@ -1200,7 +1202,7 @@ static SEXP mori_open_path(SEXP name, SEXP path_sxp) {
 
   SEXP result = mori_unwrap_element(cur_base, cur_region_size,
                                     leaf_idx, keeper);
-  UNPROTECT(nprotect);
+  UNPROTECT(2);
   return result;
 }
 

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -10,7 +10,9 @@ static R_altrep_class_t mori_logical_class;
 static R_altrep_class_t mori_raw_class;
 static R_altrep_class_t mori_complex_class;
 static R_altrep_class_t mori_string_class;
-static SEXP mori_tag;
+static SEXP mori_tag;        /* ALTLIST cache sentinel */
+static SEXP mori_shm_tag;    /* tag on shm extptrs (addr is mori_shm *) */
+static SEXP mori_view_tag;   /* tag on view extptrs (addr is mori_list_view *) */
 
 // Element directory (for list SHM layout) -------------------------------------
 
@@ -277,10 +279,15 @@ static SEXP mori_make_string(const unsigned char *region_base,
   return result;
 }
 
-// Element extraction helper (shared by list Elt and open_element) -------------
+// Forward declarations --------------------------------------------------------
 
-static SEXP mori_unwrap_element(unsigned char *base, int32_t index,
-                                SEXP shm_ptr) {
+static SEXP mori_make_list_view(unsigned char *base, int64_t region_size,
+                                int32_t index, SEXP keeper);
+
+// Element extraction helper (shared by list Elt and open_path) ----------------
+
+static SEXP mori_unwrap_element(unsigned char *base, int64_t region_size,
+                                int32_t index, SEXP keeper) {
 
   unsigned char *dir = base + 24 + 32 * (size_t) index;
   int64_t data_offset, data_size, length;
@@ -291,15 +298,27 @@ static SEXP mori_unwrap_element(unsigned char *base, int32_t index,
   memcpy(&attrs_size, dir + 20, 4);
   memcpy(&length, dir + 24, 8);
 
+  /* Bounds-check the data region against the enclosing region */
+  if (data_offset < 0 || data_size < 0 ||
+      data_offset + data_size > region_size)
+    Rf_error("mori:element data out of bounds");
+  if (attrs_size > 0 && attrs_size > data_size)
+    Rf_error("mori:element attrs size larger than data");
+
   SEXP result;
-  if (sexptype == STRSXP) {
+  if (sexptype == VECSXP) {
+    /* Nested MORL at base+data_offset; attrs live inside child region */
+    result = PROTECT(mori_make_list_view(
+      base + data_offset, data_size, index, keeper
+    ));
+  } else if (sexptype == STRSXP) {
     result = PROTECT(mori_make_string(
-      base + data_offset, (R_xlen_t) length, shm_ptr
+      base + data_offset, (R_xlen_t) length, keeper
     ));
     ((mori_str *) R_ExternalPtrAddr(R_altrep_data1(result)))->index = index;
   } else if (sexptype != 0) {
     result = PROTECT(mori_make_vector(
-      base + data_offset, (R_xlen_t) length, sexptype, shm_ptr
+      base + data_offset, (R_xlen_t) length, sexptype, keeper
     ));
     ((mori_vec *) R_ExternalPtrAddr(R_altrep_data1(result)))->index = index;
   } else {
@@ -308,7 +327,7 @@ static SEXP mori_unwrap_element(unsigned char *base, int32_t index,
     ));
   }
 
-  if (attrs_size > 0 && sexptype != 0) {
+  if (attrs_size > 0 && sexptype != 0 && sexptype != VECSXP) {
     size_t attrs_off = (size_t)(data_offset + data_size - attrs_size);
     mori_restore_attrs(result, base + attrs_off, (size_t) attrs_size);
   }
@@ -321,10 +340,11 @@ static SEXP mori_unwrap_element(unsigned char *base, int32_t index,
 
 /*
  * Layout:
- *   data1 = extptr to mori_shm (daemon-side, mmap'd read-only)
- *   data2 = cache VECSXP (length n, initialized to mori_tag)
+ *   data1 = extptr (tag = mori_view_tag) to mori_list_view
+ *           prot: parent extptr (shm for root; parent view for sub-list)
+ *   data2 = R_NilValue or cache VECSXP (length n, initialized to mori_tag)
  *
- * SHM layout:
+ * MORL region layout (same whether root SHM or nested inside a parent):
  *   Bytes 0-3:   uint32_t magic (0x4D4F524C "MORL")
  *   Bytes 4-7:   int32_t  n_elements
  *   Bytes 8-15:  int64_t  attrs_offset
@@ -332,21 +352,78 @@ static SEXP mori_unwrap_element(unsigned char *base, int32_t index,
  *   Byte 24+:    element directory (32 bytes per element)
  */
 
+/* keeper: parent extptr (shm_tag for root, view_tag for sub-list).
+   Validates the MORL header before touching it so corrupt input errors
+   cleanly rather than SEGV. */
+static SEXP mori_make_list_view(unsigned char *base, int64_t region_size,
+                                int32_t index, SEXP keeper) {
+
+  if (region_size < 24)
+    Rf_error("mori:nested list region too small");
+
+  uint32_t magic;
+  memcpy(&magic, base, 4);
+  if (magic != 0x4D4F524Cu)
+    Rf_error("mori:invalid nested list magic bytes");
+
+  int32_t n;
+  int64_t attrs_offset, attrs_size;
+  memcpy(&n, base + 4, 4);
+  memcpy(&attrs_offset, base + 8, 8);
+  memcpy(&attrs_size, base + 16, 8);
+
+  if (n < 0 || (int64_t) 24 + (int64_t) 32 * n > region_size)
+    Rf_error("mori:nested list directory out of bounds");
+  if (attrs_offset < 0 || attrs_size < 0 ||
+      attrs_offset + attrs_size > region_size)
+    Rf_error("mori:nested list attrs out of bounds");
+
+  mori_list_view *v = (mori_list_view *) malloc(sizeof(mori_list_view));
+  if (!v) Rf_error("mori:allocation failure");
+  v->base = base;
+  v->region_size = region_size;
+  v->n_elements = n;
+  v->index = index;
+
+  SEXP ptr = PROTECT(R_MakeExternalPtr(v, mori_view_tag, keeper));
+  R_RegisterCFinalizerEx(ptr, mori_vec_finalizer, TRUE);
+
+  /* Cache is allocated lazily on first Elt access */
+  SEXP result = PROTECT(R_new_altrep(mori_list_class, ptr, R_NilValue));
+
+  if (attrs_size > 0)
+    mori_restore_attrs(result, base + (size_t) attrs_offset,
+                       (size_t) attrs_size);
+
+  UNPROTECT(2);
+  return result;
+}
+
 static R_xlen_t mori_list_Length(SEXP x) {
-  return XLENGTH(R_altrep_data2(x));
+  mori_list_view *v = (mori_list_view *) R_ExternalPtrAddr(R_altrep_data1(x));
+  return v != NULL ? v->n_elements : 0;
 }
 
 static SEXP mori_list_Elt(SEXP x, R_xlen_t i) {
 
+  SEXP d1 = R_altrep_data1(x);
+  mori_list_view *view = (mori_list_view *) R_ExternalPtrAddr(d1);
+
+  /* Lazy cache allocation */
   SEXP cache = R_altrep_data2(x);
+  if (cache == R_NilValue) {
+    cache = PROTECT(Rf_allocVector(VECSXP, view->n_elements));
+    for (int32_t k = 0; k < view->n_elements; k++)
+      SET_VECTOR_ELT(cache, k, mori_tag);
+    R_set_altrep_data2(x, cache);
+    UNPROTECT(1);
+  }
+
   SEXP cached = VECTOR_ELT(cache, i);
   if (cached != mori_tag) return cached;
 
-  SEXP shm_ptr = R_altrep_data1(x);
-  mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
-  unsigned char *base = (unsigned char *) shm->addr;
-
-  SEXP result = mori_unwrap_element(base, (int32_t) i, shm_ptr);
+  SEXP result = mori_unwrap_element(view->base, view->region_size,
+                                    (int32_t) i, d1);
   SET_VECTOR_ELT(cache, i, result);
   return result;
 }
@@ -358,15 +435,20 @@ static const void *mori_list_Dataptr_or_null(SEXP x) {
 
 /* Full materialization fallback */
 static void *mori_list_Dataptr(SEXP x, Rboolean writable) {
-  R_xlen_t n = XLENGTH(x);
+  R_xlen_t n = mori_list_Length(x);
   for (R_xlen_t i = 0; i < n; i++)
     mori_list_Elt(x, i);
+  if (R_altrep_data2(x) == R_NilValue) {
+    SEXP cache = PROTECT(Rf_allocVector(VECSXP, n));
+    R_set_altrep_data2(x, cache);
+    UNPROTECT(1);
+  }
   return mori_data_ptr(R_altrep_data2(x));
 }
 
 /* COW: modification produces a regular list */
 static SEXP mori_list_Duplicate(SEXP x, Rboolean deep) {
-  R_xlen_t n = XLENGTH(x);
+  R_xlen_t n = mori_list_Length(x);
   SEXP result = PROTECT(Rf_allocVector(VECSXP, n));
   for (R_xlen_t i = 0; i < n; i++) {
     SEXP elt = mori_list_Elt(x, i);
@@ -406,8 +488,9 @@ static SEXP mori_make_result(mori_shm *shm) {
   SEXP result;
   if (magic == 0x4D4F524Cu) {
     result = PROTECT(mori_open_list(shm));
-    /* Chain: list data1 (shm_ptr) protects host_ptr */
-    R_SetExternalPtrProtected(R_altrep_data1(result), host_ptr);
+    /* Chain: view data1's keeper (shm_ptr) protects host_ptr */
+    R_SetExternalPtrProtected(
+      R_ExternalPtrProtected(R_altrep_data1(result)), host_ptr);
   } else if (magic == 0x4D4F5248u) {
     result = PROTECT(mori_open_vector(shm));
     /* Chain: vec data1's keeper (shm_ptr) protects host_ptr */
@@ -481,80 +564,137 @@ static size_t mori_string_data_size(SEXP x) {
 
 // .Call entry points: host-side SHM creation ---------------------------------
 
-/* Zero-copy: list/data frame to SHM */
-static SEXP mori_shm_create_list_call(SEXP x) {
+// Recursive size/write helpers for nested list regions -----------------------
 
-  /* Coerce pairlists to VECSXP so VECTOR_ELT/XLENGTH work uniformly */
-  if (TYPEOF(x) == LISTSXP) {
-    x = PROTECT(Rf_coerceVector(x, VECSXP));
-  } else {
-    PROTECT(x);
-  }
+static size_t mori_nested_size(SEXP x);
+static size_t mori_nested_write(unsigned char *base, SEXP x);
+
+/* Total bytes occupied by a MORL region for VECSXP x, including header,
+   directory, elements (recursing into VECSXP/LISTSXP children), trailing
+   attrs, and all 64-byte alignment padding. Caller passes a VECSXP; any
+   LISTSXP children are coerced locally during recursion. */
+static size_t mori_nested_size(SEXP x) {
 
   R_xlen_t n = XLENGTH(x);
-  size_t dir_size = 24 + 32 * (size_t) n;
-  size_t total = MORI_ALIGN64(dir_size);
+  size_t total = MORI_ALIGN64(24 + 32 * (size_t) n);
 
-  mori_elem *elems = (mori_elem *) R_alloc((size_t) n, sizeof(mori_elem));
+  for (R_xlen_t i = 0; i < n; i++) {
+    SEXP elt = VECTOR_ELT(x, i);
+    int type = TYPEOF(elt);
+    size_t elt_size;
 
-  /* First pass: compute element sizes and offsets */
+    if (type == LISTSXP || type == VECSXP) {
+      SEXP coerced = (type == LISTSXP) ? Rf_coerceVector(elt, VECSXP) : elt;
+      PROTECT(coerced);
+      elt_size = mori_nested_size(coerced);
+      UNPROTECT(1);
+    } else if (mori_shm_eligible(type)) {
+      size_t raw_size = (type == STRSXP) ?
+        mori_string_data_size(elt) :
+        (size_t) XLENGTH(elt) * mori_sizeof_elt(type);
+      SEXP elt_attrs = PROTECT(mori_get_attrs_for_serialize(elt));
+      size_t attrs_size = (elt_attrs != R_NilValue) ?
+        mori_serialize_count(elt_attrs) : 0;
+      UNPROTECT(1);
+      elt_size = raw_size + attrs_size;
+    } else {
+      elt_size = mori_serialize_count(elt);
+    }
+
+    total += MORI_ALIGN64(elt_size);
+  }
+
+  SEXP attrs = PROTECT(mori_get_attrs_for_serialize(x));
+  size_t attrs_size = (attrs != R_NilValue) ?
+    mori_serialize_count(attrs) : 0;
+  UNPROTECT(1);
+  total += MORI_ALIGN64(attrs_size);
+
+  return total;
+}
+
+/* Writes a complete MORL region for VECSXP x starting at base. Returns
+   total bytes written (must equal mori_nested_size(x)). */
+static size_t mori_nested_write(unsigned char *base, SEXP x) {
+
+  R_xlen_t n = XLENGTH(x);
+  size_t cur = MORI_ALIGN64(24 + 32 * (size_t) n);
+
+  mori_elem *elems = (n > 0) ?
+    (mori_elem *) R_alloc((size_t) n, sizeof(mori_elem)) : NULL;
+
   for (R_xlen_t i = 0; i < n; i++) {
     SEXP elt = VECTOR_ELT(x, i);
     int type = TYPEOF(elt);
 
-    if (mori_shm_eligible(type)) {
-      elems[i].sexptype = type;
-      elems[i].length = (int64_t) XLENGTH(elt);
+    elems[i].data_offset = (int64_t) cur;
 
-      size_t raw_size;
-      if (type == STRSXP)
-        raw_size = mori_string_data_size(elt);
-      else
-        raw_size = (size_t) XLENGTH(elt) * mori_sizeof_elt(type);
+    if (type == LISTSXP || type == VECSXP) {
+      SEXP coerced = (type == LISTSXP) ? Rf_coerceVector(elt, VECSXP) : elt;
+      PROTECT(coerced);
+      size_t written = mori_nested_write(base + cur, coerced);
+      elems[i].sexptype = VECSXP;
+      elems[i].attrs_size = 0;
+      elems[i].length = (int64_t) XLENGTH(coerced);
+      elems[i].data_size = (int64_t) written;
+      UNPROTECT(1);
+      cur += MORI_ALIGN64(written);
+    } else if (mori_shm_eligible(type)) {
+      size_t raw_size = (type == STRSXP) ?
+        mori_string_data_size(elt) :
+        (size_t) XLENGTH(elt) * mori_sizeof_elt(type);
 
       SEXP elt_attrs = PROTECT(mori_get_attrs_for_serialize(elt));
-      if (elt_attrs != R_NilValue) {
-        size_t elt_attrs_size = mori_serialize_count(elt_attrs);
-        elems[i].attrs_size = (int32_t) elt_attrs_size;
-        elems[i].data_size = (int64_t)(raw_size + elt_attrs_size);
+      size_t attrs_size = (elt_attrs != R_NilValue) ?
+        mori_serialize_count(elt_attrs) : 0;
+
+      elems[i].sexptype = type;
+      elems[i].attrs_size = (int32_t) attrs_size;
+      elems[i].length = (int64_t) XLENGTH(elt);
+      elems[i].data_size = (int64_t) (raw_size + attrs_size);
+
+      if (type == STRSXP) {
+        size_t written = mori_write_strings(base + cur, elt);
+        if (attrs_size > 0)
+          mori_serialize_into(base + cur + written, attrs_size, elt_attrs);
       } else {
-        elems[i].attrs_size = 0;
-        elems[i].data_size = (int64_t) raw_size;
+        memcpy(base + cur, DATAPTR_RO(elt), raw_size);
+        if (attrs_size > 0)
+          mori_serialize_into(base + cur + raw_size, attrs_size, elt_attrs);
       }
+
       UNPROTECT(1);
+      cur += MORI_ALIGN64((size_t) elems[i].data_size);
     } else {
+      size_t elt_size = mori_serialize_count(elt);
+      mori_serialize_into(base + cur, elt_size, elt);
       elems[i].sexptype = 0;
       elems[i].attrs_size = 0;
       elems[i].length = 0;
-      elems[i].data_size = (int64_t) mori_serialize_count(elt);
+      elems[i].data_size = (int64_t) elt_size;
+      cur += MORI_ALIGN64(elt_size);
     }
-    elems[i].data_offset = (int64_t) total;
-    total += MORI_ALIGN64((size_t) elems[i].data_size);
   }
 
-  /* Compute serialized attributes size */
   SEXP list_attrs = PROTECT(mori_get_attrs_for_serialize(x));
   size_t attrs_size = (list_attrs != R_NilValue) ?
     mori_serialize_count(list_attrs) : 0;
-  size_t attrs_offset = total;
-  total += MORI_ALIGN64(attrs_size);
-
-  mori_shm shm;
-  if (mori_shm_create(&shm, total) != 0)
-    Rf_error("mori:failed to create shared memory");
-
-  unsigned char *base = (unsigned char *) shm.addr;
+  int64_t attrs_offset = (int64_t) cur;
+  if (attrs_size > 0)
+    mori_serialize_into(base + cur, attrs_size, list_attrs);
+  cur += MORI_ALIGN64(attrs_size);
+  UNPROTECT(1);
 
   /* Write header */
   uint32_t magic = 0x4D4F524Cu;
   int32_t n32 = (int32_t) n;
-  int64_t ao = (int64_t) attrs_offset, as = (int64_t) attrs_size;
+  int64_t as64 = (int64_t) attrs_size;
   memcpy(base, &magic, 4);
   memcpy(base + 4, &n32, 4);
-  memcpy(base + 8, &ao, 8);
-  memcpy(base + 16, &as, 8);
+  memcpy(base + 8, &attrs_offset, 8);
+  memcpy(base + 16, &as64, 8);
 
-  /* Write element directory and data */
+  /* Write directory */
   for (R_xlen_t i = 0; i < n; i++) {
     unsigned char *d = base + 24 + 32 * (size_t) i;
     memcpy(d, &elems[i].data_offset, 8);
@@ -562,37 +702,32 @@ static SEXP mori_shm_create_list_call(SEXP x) {
     memcpy(d + 16, &elems[i].sexptype, 4);
     memcpy(d + 20, &elems[i].attrs_size, 4);
     memcpy(d + 24, &elems[i].length, 8);
-
-    SEXP elt = VECTOR_ELT(x, i);
-    if (elems[i].sexptype == STRSXP) {
-      size_t written = mori_write_strings(base + elems[i].data_offset, elt);
-      if (elems[i].attrs_size > 0) {
-        SEXP ea = PROTECT(mori_get_attrs_for_serialize(elt));
-        mori_serialize_into(base + elems[i].data_offset + written,
-                            (size_t) elems[i].attrs_size, ea);
-        UNPROTECT(1);
-      }
-    } else if (elems[i].sexptype != 0) {
-      size_t raw_size = (size_t) XLENGTH(elt) *
-                        mori_sizeof_elt(elems[i].sexptype);
-      memcpy(base + elems[i].data_offset, DATAPTR_RO(elt), raw_size);
-      if (elems[i].attrs_size > 0) {
-        SEXP ea = PROTECT(mori_get_attrs_for_serialize(elt));
-        mori_serialize_into(base + elems[i].data_offset + raw_size,
-                            (size_t) elems[i].attrs_size, ea);
-        UNPROTECT(1);
-      }
-    } else {
-      mori_serialize_into(base + elems[i].data_offset,
-                          (size_t) elems[i].data_size, elt);
-    }
   }
 
-  /* Write serialized attributes */
-  if (attrs_size > 0)
-    mori_serialize_into(base + attrs_offset, attrs_size, list_attrs);
+  return cur;
+}
 
-  UNPROTECT(2);
+/* Zero-copy: list/data frame to SHM (with transparent nested VECSXP) */
+static SEXP mori_shm_create_list_call(SEXP x) {
+
+  /* Coerce top-level pairlists to VECSXP so VECTOR_ELT/XLENGTH work */
+  if (TYPEOF(x) == LISTSXP) {
+    x = PROTECT(Rf_coerceVector(x, VECSXP));
+  } else {
+    PROTECT(x);
+  }
+
+  size_t total = mori_nested_size(x);
+
+  mori_shm shm;
+  if (mori_shm_create(&shm, total) != 0) {
+    UNPROTECT(1);
+    Rf_error("mori:failed to create shared memory");
+  }
+
+  mori_nested_write((unsigned char *) shm.addr, x);
+
+  UNPROTECT(1);
   return mori_make_result(&shm);
 }
 
@@ -685,35 +820,21 @@ SEXP mori_create(SEXP x) {
 
 // .Call entry points: daemon-side SHM open and wrap --------------------------
 
-/* Open SHM and create ALTLIST wrapper */
+/* Open SHM and create ALTLIST wrapper (root view, index = -1) */
 static SEXP mori_open_list(mori_shm *shm_stack) {
 
   mori_shm *shm = (mori_shm *) malloc(sizeof(mori_shm));
   if (!shm) Rf_error("mori:allocation failure");
   memcpy(shm, shm_stack, sizeof(mori_shm));
 
-  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_tag, R_NilValue));
+  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_shm_tag, R_NilValue));
   R_RegisterCFinalizerEx(shm_ptr, mori_shm_finalizer, TRUE);
 
-  unsigned char *base = (unsigned char *) shm->addr;
-  int32_t n;
-  int64_t attrs_offset, attrs_size;
-  memcpy(&n, base + 4, 4);
-  memcpy(&attrs_offset, base + 8, 8);
-  memcpy(&attrs_size, base + 16, 8);
+  SEXP result = mori_make_list_view(
+    (unsigned char *) shm->addr, (int64_t) shm->size, -1, shm_ptr
+  );
 
-  /* Cache filled with sentinel (mori_tag means "not yet accessed") */
-  SEXP cache = PROTECT(Rf_allocVector(VECSXP, (R_xlen_t) n));
-  for (int32_t i = 0; i < n; i++)
-    SET_VECTOR_ELT(cache, i, mori_tag);
-
-  SEXP result = PROTECT(R_new_altrep(mori_list_class, shm_ptr, cache));
-
-  if (attrs_size > 0)
-    mori_restore_attrs(result, base + (size_t) attrs_offset,
-                       (size_t) attrs_size);
-
-  UNPROTECT(3);
+  UNPROTECT(1);
   return result;
 }
 
@@ -724,7 +845,7 @@ static SEXP mori_open_vector(mori_shm *shm_stack) {
   if (!shm) Rf_error("mori:allocation failure");
   memcpy(shm, shm_stack, sizeof(mori_shm));
 
-  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_tag, R_NilValue));
+  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_shm_tag, R_NilValue));
   R_RegisterCFinalizerEx(shm_ptr, mori_shm_finalizer, TRUE);
 
   unsigned char *base = (unsigned char *) shm->addr;
@@ -756,7 +877,7 @@ static SEXP mori_open_string(mori_shm *shm_stack) {
   if (!shm) Rf_error("mori:allocation failure");
   memcpy(shm, shm_stack, sizeof(mori_shm));
 
-  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_tag, R_NilValue));
+  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_shm_tag, R_NilValue));
   R_RegisterCFinalizerEx(shm_ptr, mori_shm_finalizer, TRUE);
 
   unsigned char *base = (unsigned char *) shm->addr;
@@ -819,41 +940,96 @@ SEXP mori_shm_open_and_wrap(SEXP name) {
 }
 
 SEXP mori_is_shared(SEXP x) {
-  if (ALTREP(x)) {
-    SEXP d1 = R_altrep_data1(x);
-    if (TYPEOF(d1) == EXTPTRSXP) {
-      /* List: data1 is shm_ptr directly */
-      if (R_ExternalPtrTag(d1) == mori_tag)
-        return Rf_ScalarLogical(1);
-      /* Vec/str: data1's prot is shm_ptr */
-      SEXP prot = R_ExternalPtrProtected(d1);
-      if (TYPEOF(prot) == EXTPTRSXP &&
-          R_ExternalPtrTag(prot) == mori_tag)
-        return Rf_ScalarLogical(1);
-    }
+  if (!ALTREP(x)) return Rf_ScalarLogical(0);
+  SEXP d1 = R_altrep_data1(x);
+  if (TYPEOF(d1) != EXTPTRSXP) return Rf_ScalarLogical(0);
+  SEXP tag = R_ExternalPtrTag(d1);
+  /* List (root or sub-list): data1 tag == mori_view_tag */
+  if (tag == mori_view_tag) return Rf_ScalarLogical(1);
+  /* Vec/str: data1's prot is either a view extptr or the root shm extptr */
+  SEXP prot = R_ExternalPtrProtected(d1);
+  if (TYPEOF(prot) == EXTPTRSXP) {
+    SEXP ptag = R_ExternalPtrTag(prot);
+    if (ptag == mori_view_tag || ptag == mori_shm_tag)
+      return Rf_ScalarLogical(1);
   }
   return Rf_ScalarLogical(0);
 }
 
 SEXP mori_shm_name(SEXP x) {
-  if (ALTREP(x)) {
-    SEXP d1 = R_altrep_data1(x);
-    if (TYPEOF(d1) == EXTPTRSXP) {
-      /* Vec/str: data1 tag is the name */
-      SEXP tag = R_ExternalPtrTag(d1);
-      if (tag != R_NilValue && TYPEOF(tag) == CHARSXP)
-        return Rf_ScalarString(tag);
-      /* List: data1 is shm_ptr, name is in C struct */
-      if (tag == mori_tag) {
-        mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(d1);
-        if (shm && shm->name[0] != '\0') return Rf_mkString(shm->name);
+  if (!ALTREP(x)) return R_BlankScalarString;
+  SEXP d1 = R_altrep_data1(x);
+  if (TYPEOF(d1) != EXTPTRSXP) return R_BlankScalarString;
+  SEXP tag = R_ExternalPtrTag(d1);
+
+  /* Standalone vec/str: data1 tag is CHARSXP name */
+  if (tag != R_NilValue && TYPEOF(tag) == CHARSXP)
+    return Rf_ScalarString(tag);
+
+  /* List: data1 is a view extptr */
+  if (tag == mori_view_tag) {
+    mori_list_view *v = (mori_list_view *) R_ExternalPtrAddr(d1);
+    if (v != NULL && v->index == -1) {
+      /* Root view: prot is the shm extptr (guaranteed shm_tag) */
+      SEXP shm_ptr = R_ExternalPtrProtected(d1);
+      if (TYPEOF(shm_ptr) == EXTPTRSXP &&
+          R_ExternalPtrTag(shm_ptr) == mori_shm_tag) {
+        mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
+        if (shm != NULL && shm->name[0] != '\0')
+          return Rf_mkString(shm->name);
       }
     }
+    /* Sub-list (index >= 0): no standalone name */
   }
+
   return R_BlankScalarString;
 }
 
 // ALTREP serialization hooks --------------------------------------------------
+
+/* Walks the keeper chain through view extptrs and returns list(name, path)
+   where path is an INTSXP of (collected indices + leaf_index) in top-down
+   order. Returns R_NilValue if the chain is invalid or the root SHM has
+   been invalidated. */
+#define MORI_MAX_PATH 64
+
+static SEXP mori_build_path(SEXP keeper_extptr, int32_t leaf_index) {
+
+  int32_t collected[MORI_MAX_PATH];
+  int n_collected = 0;
+
+  SEXP hop = keeper_extptr;
+  while (TYPEOF(hop) == EXTPTRSXP &&
+         R_ExternalPtrTag(hop) == mori_view_tag) {
+    mori_list_view *view = (mori_list_view *) R_ExternalPtrAddr(hop);
+    if (view == NULL) return R_NilValue;
+    if (view->index >= 0) {
+      if (n_collected >= MORI_MAX_PATH) return R_NilValue;
+      collected[n_collected++] = view->index;
+    }
+    hop = R_ExternalPtrProtected(hop);
+  }
+
+  if (TYPEOF(hop) != EXTPTRSXP ||
+      R_ExternalPtrTag(hop) != mori_shm_tag)
+    return R_NilValue;
+
+  mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(hop);
+  if (shm == NULL || shm->name[0] == '\0') return R_NilValue;
+
+  SEXP path = PROTECT(Rf_allocVector(INTSXP, n_collected + 1));
+  int *pp = INTEGER(path);
+  for (int i = 0; i < n_collected; i++)
+    pp[i] = collected[n_collected - 1 - i];
+  pp[n_collected] = leaf_index;
+
+  SEXP state = PROTECT(Rf_allocVector(VECSXP, 2));
+  SET_VECTOR_ELT(state, 0, Rf_mkString(shm->name));
+  SET_VECTOR_ELT(state, 1, path);
+
+  UNPROTECT(2);
+  return state;
+}
 
 static SEXP mori_vec_Serialized_state(SEXP x) {
   SEXP data1 = R_altrep_data1(x);
@@ -869,18 +1045,11 @@ static SEXP mori_vec_Serialized_state(SEXP x) {
   if (R_altrep_data2(x) != R_NilValue)
     return R_altrep_data2(x);
 
-  /* Element of ALTLIST with valid parent SHM → compact (name, index) */
+  /* Element (index >= 0) → build path via keeper chain */
   mori_vec *v = (mori_vec *) R_ExternalPtrAddr(data1);
   if (v != NULL && v->index >= 0) {
-    SEXP keeper = R_ExternalPtrProtected(data1);
-    mori_shm *parent = (mori_shm *) R_ExternalPtrAddr(keeper);
-    if (parent != NULL && parent->name[0] != '\0') {
-      SEXP state = PROTECT(Rf_allocVector(VECSXP, 2));
-      SET_VECTOR_ELT(state, 0, Rf_mkString(parent->name));
-      SET_VECTOR_ELT(state, 1, Rf_ScalarInteger(v->index));
-      UNPROTECT(1);
-      return state;
-    }
+    SEXP state = mori_build_path(R_ExternalPtrProtected(data1), v->index);
+    if (state != R_NilValue) return state;
   }
 
   /* Closed, detached, or invalidated → materialize from SHM */
@@ -906,18 +1075,10 @@ static SEXP mori_string_Serialized_state(SEXP x) {
   if (R_altrep_data2(x) != R_NilValue)
     return R_altrep_data2(x);
 
-  /* Element of ALTLIST with valid parent SHM → compact (name, index) */
   mori_str *s = (mori_str *) R_ExternalPtrAddr(data1);
   if (s != NULL && s->index >= 0) {
-    SEXP keeper = R_ExternalPtrProtected(data1);
-    mori_shm *parent = (mori_shm *) R_ExternalPtrAddr(keeper);
-    if (parent != NULL && parent->name[0] != '\0') {
-      SEXP state = PROTECT(Rf_allocVector(VECSXP, 2));
-      SET_VECTOR_ELT(state, 0, Rf_mkString(parent->name));
-      SET_VECTOR_ELT(state, 1, Rf_ScalarInteger(s->index));
-      UNPROTECT(1);
-      return state;
-    }
+    SEXP state = mori_build_path(R_ExternalPtrProtected(data1), s->index);
+    if (state != R_NilValue) return state;
   }
 
   /* Closed, detached, or invalidated → materialize from SHM */
@@ -933,29 +1094,41 @@ static SEXP mori_string_Serialized_state(SEXP x) {
 
 static SEXP mori_list_Serialized_state(SEXP x) {
   SEXP data1 = R_altrep_data1(x);
-  mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(data1);
+  if (R_ExternalPtrTag(data1) != mori_view_tag)
+    return Rf_allocVector(VECSXP, 0);
 
-  if (R_ExternalPtrTag(data1) == mori_tag && shm != NULL &&
-      shm->name[0] != '\0')
-    return Rf_mkString(shm->name);
+  mori_list_view *view = (mori_list_view *) R_ExternalPtrAddr(data1);
+  if (view == NULL) return Rf_allocVector(VECSXP, 0);
 
-  /* Invalidated (SHM still mapped) → materialize */
-  if (R_ExternalPtrTag(data1) == mori_tag && shm != NULL) {
-    R_xlen_t n = XLENGTH(x);
-    SEXP mat = PROTECT(Rf_allocVector(VECSXP, n));
-    for (R_xlen_t i = 0; i < n; i++)
-      SET_VECTOR_ELT(mat, i, mori_list_Elt(x, i));
-    DUPLICATE_ATTRIB(mat, x);
-    UNPROTECT(1);
-    return mat;
+  if (view->index == -1) {
+    /* Root list: compact name scalar */
+    SEXP shm_ptr = R_ExternalPtrProtected(data1);
+    if (TYPEOF(shm_ptr) == EXTPTRSXP &&
+        R_ExternalPtrTag(shm_ptr) == mori_shm_tag) {
+      mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
+      if (shm != NULL && shm->name[0] != '\0')
+        return Rf_mkString(shm->name);
+    }
+  } else {
+    /* Sub-list: build (name, path) */
+    SEXP state = mori_build_path(R_ExternalPtrProtected(data1), view->index);
+    if (state != R_NilValue) return state;
   }
 
-  /* Closed (extptr cleared) → empty */
-  return Rf_allocVector(VECSXP, 0);
+  /* Fallback: materialize */
+  R_xlen_t n = view->n_elements;
+  SEXP mat = PROTECT(Rf_allocVector(VECSXP, n));
+  for (R_xlen_t i = 0; i < n; i++)
+    SET_VECTOR_ELT(mat, i, mori_list_Elt(x, i));
+  DUPLICATE_ATTRIB(mat, x);
+  UNPROTECT(1);
+  return mat;
 }
 
-/* Open parent SHM and extract a single element by index */
-static SEXP mori_open_element(SEXP name, int32_t index) {
+/* Open parent SHM and walk the path, returning the leaf element.
+   path is an INTSXP of length >= 1. Intermediate steps must be VECSXP
+   children (nested MORL regions); the final step is the leaf. */
+static SEXP mori_open_path(SEXP name, SEXP path_sxp) {
 
   const char *nm = CHAR(STRING_ELT(name, 0));
 
@@ -978,28 +1151,76 @@ static SEXP mori_open_element(SEXP name, int32_t index) {
   }
   memcpy(shm, &shm_stack, sizeof(mori_shm));
 
-  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_tag, R_NilValue));
+  SEXP shm_ptr = PROTECT(R_MakeExternalPtr(shm, mori_shm_tag, R_NilValue));
   R_RegisterCFinalizerEx(shm_ptr, mori_shm_finalizer, TRUE);
 
-  SEXP result = mori_unwrap_element(base, index, shm_ptr);
-  UNPROTECT(1);
+  int path_len = (int) XLENGTH(path_sxp);
+  const int *path = INTEGER(path_sxp);
+
+  SEXP keeper = shm_ptr;
+  int nprotect = 1;
+  unsigned char *cur_base = base;
+  int64_t cur_region_size = (int64_t) shm_stack.size;
+  int32_t cur_n;
+  memcpy(&cur_n, cur_base + 4, 4);
+
+  /* Walk intermediate VECSXP levels */
+  for (int k = 0; k < path_len - 1; k++) {
+    int idx = path[k];
+    if (idx < 0 || idx >= cur_n)
+      Rf_error("mori:path index out of bounds");
+
+    unsigned char *dir = cur_base + 24 + 32 * (size_t) idx;
+    int64_t data_offset, data_size;
+    int32_t sexptype;
+    memcpy(&data_offset, dir, 8);
+    memcpy(&data_size, dir + 8, 8);
+    memcpy(&sexptype, dir + 16, 4);
+
+    if (sexptype != VECSXP)
+      Rf_error("mori:path step is not a nested list");
+    if (data_offset < 0 || data_size < 0 ||
+        data_offset + data_size > cur_region_size)
+      Rf_error("mori:nested region out of bounds");
+
+    SEXP child = PROTECT(mori_make_list_view(
+      cur_base + data_offset, data_size, idx, keeper
+    ));
+    nprotect++;
+    keeper = R_altrep_data1(child);
+
+    cur_base = cur_base + data_offset;
+    cur_region_size = data_size;
+    memcpy(&cur_n, cur_base + 4, 4);
+  }
+
+  int leaf_idx = path[path_len - 1];
+  if (leaf_idx < 0 || leaf_idx >= cur_n)
+    Rf_error("mori:leaf index out of bounds");
+
+  SEXP result = mori_unwrap_element(cur_base, cur_region_size,
+                                    leaf_idx, keeper);
+  UNPROTECT(nprotect);
   return result;
 }
 
 static SEXP mori_Unserialize(SEXP class_info, SEXP state) {
   (void) class_info;
-  /* Compact state: SHM name string → open and wrap */
+  /* Compact state: SHM name string → open and wrap (root) */
   if (TYPEOF(state) == STRSXP && XLENGTH(state) == 1 &&
+      STRING_ELT(state, 0) != NA_STRING &&
       mori_is_shm_name(CHAR(STRING_ELT(state, 0))))
     return mori_shm_open_and_wrap(state);
-  /* Element reference: list(name, index) → open parent, extract element */
+  /* Path reference: list(name, int_path) where int_path has length >= 1.
+     Length 1 is wire-compatible with the previous (name, scalar_int) form. */
   if (TYPEOF(state) == VECSXP && XLENGTH(state) == 2 &&
       TYPEOF(VECTOR_ELT(state, 0)) == STRSXP &&
       XLENGTH(VECTOR_ELT(state, 0)) == 1 &&
+      STRING_ELT(VECTOR_ELT(state, 0), 0) != NA_STRING &&
       TYPEOF(VECTOR_ELT(state, 1)) == INTSXP &&
+      XLENGTH(VECTOR_ELT(state, 1)) >= 1 &&
       mori_is_shm_name(CHAR(STRING_ELT(VECTOR_ELT(state, 0), 0))))
-    return mori_open_element(VECTOR_ELT(state, 0),
-                             INTEGER(VECTOR_ELT(state, 1))[0]);
+    return mori_open_path(VECTOR_ELT(state, 0), VECTOR_ELT(state, 1));
   /* Expanded state: materialized data → return as-is
      (R restores ALTREP attributes separately) */
   return state;
@@ -1010,6 +1231,8 @@ static SEXP mori_Unserialize(SEXP class_info, SEXP state) {
 void mori_altrep_init(DllInfo *dll) {
 
   mori_tag = Rf_install("mori");
+  mori_shm_tag = Rf_install("mori_shm");
+  mori_view_tag = Rf_install("mori_view");
 
   /* ALTLIST class */
   mori_list_class = R_make_altlist_class("mori_list", "mori", dll);

--- a/src/mori.h
+++ b/src/mori.h
@@ -31,6 +31,13 @@ typedef struct mori_vec_s {
   int32_t index;   /* -1 = standalone, >= 0 = element of ALTLIST */
 } mori_vec;
 
+typedef struct mori_list_view_s {
+  unsigned char *base;       /* points to child MORL start */
+  int64_t region_size;       /* bounds all reads within this region */
+  int32_t n_elements;
+  int32_t index;             /* -1 = root, >= 0 = sub-list */
+} mori_list_view;
+
 // shm.c -----------------------------------------------------------------------
 
 int mori_shm_create(mori_shm *shm, size_t size);

--- a/tests/testthat/test-list.R
+++ b/tests/testthat/test-list.R
@@ -65,3 +65,11 @@ test_that("pairlist round-trips via map_shared", {
   expect_identical(spl[[2]][], spl2[[2]][])
   expect_identical(spl[[3]], spl2[[3]])
 })
+
+test_that("share(list(list(1:5))) works directly", {
+  x <- share(list(list(1:5)))
+  expect_identical(x[[1]][[1]][], 1:5)
+  y <- map_shared(shared_name(x))
+  expect_identical(y[[1]][[1]][], 1:5)
+  expect_true(is_shared(y[[1]]))
+})

--- a/tests/testthat/test-nested.R
+++ b/tests/testthat/test-nested.R
@@ -1,0 +1,204 @@
+test_that("nested list round-trips via map_shared", {
+  x <- list(a = 1:5, b = list(c = 6:10, d = letters))
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_identical(x$a, y$a[])
+  expect_identical(x$b$c, y$b$c[])
+  expect_identical(x$b$d, y$b$d)
+})
+
+test_that("inner list on consumer is still an ALTLIST", {
+  x <- list(inner = list(a = 1:3))
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_true(is_shared(y$inner))
+  expect_true(is_shared(y$inner$a))
+})
+
+test_that("data frame with list column round-trips", {
+  df <- data.frame(a = 1:3)
+  df$b <- list(1:5, 6:10, 11:15)
+  sdf <- share(df)
+  df2 <- map_shared(shared_name(sdf))
+  expect_s3_class(df2, "data.frame")
+  expect_identical(df2$a[], 1:3)
+  expect_identical(df2$b[[1]][], 1:5)
+  expect_identical(df2$b[[2]][], 6:10)
+  expect_identical(df2$b[[3]][], 11:15)
+})
+
+test_that("list of data frames (3 levels) round-trips", {
+  x <- list(
+    df1 = data.frame(a = 1:3, b = 4:6),
+    df2 = data.frame(x = 7:9, y = 10:12)
+  )
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_s3_class(y$df1, "data.frame")
+  expect_s3_class(y$df2, "data.frame")
+  expect_identical(x$df1$a, y$df1$a[])
+  expect_identical(x$df2$y, y$df2$y[])
+})
+
+test_that("named sub-list preserves names", {
+  x <- list(outer = list(first = 1:3, second = 4:6))
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_identical(names(y$outer), c("first", "second"))
+})
+
+test_that("classed sub-list preserves class", {
+  inner <- structure(list(a = 1:3), class = "myclass")
+  x <- list(wrapped = inner)
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_s3_class(y$wrapped, "myclass")
+  expect_identical(y$wrapped$a[], 1:3)
+})
+
+test_that("factor inside a sub-list is preserved", {
+  x <- list(deep = list(f = factor(c("a", "b", "a"))))
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_s3_class(y$deep$f, "factor")
+  expect_identical(levels(y$deep$f), c("a", "b"))
+  expect_identical(as.integer(y$deep$f), c(1L, 2L, 1L))
+})
+
+test_that("empty sub-list round-trips", {
+  x <- list(empty = list())
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_identical(length(y$empty), 0L)
+})
+
+test_that("NULL elements inside a sub-list round-trip", {
+  x <- list(outer = list(NULL, 1:3, NULL))
+  sx <- share(x)
+  y <- map_shared(shared_name(sx))
+  expect_null(y$outer[[1]])
+  expect_identical(y$outer[[2]][], 1:3)
+  expect_null(y$outer[[3]])
+})
+
+test_that("sub-list alone round-trips through serialize (length>=1 path)", {
+  x <- share(list(outer = list(inner = 1:10)))
+  sub <- x$outer
+  buf <- serialize(sub, NULL)
+  expect_lt(length(buf), 1000)
+  y <- unserialize(buf)
+  expect_identical(y$inner[], 1:10)
+  expect_true(is_shared(y))
+})
+
+test_that("vec inside sub-list round-trips through serialize (depth-2 path)", {
+  x <- share(list(outer = list(inner = 1:10)))
+  vec <- x$outer$inner
+  buf <- serialize(vec, NULL)
+  expect_lt(length(buf), 1000)
+  y <- unserialize(buf)
+  expect_identical(y[], 1:10)
+})
+
+test_that("COW of sub-list does not touch parent SHM", {
+  x <- share(list(outer = list(a = 1:5, b = 6:10)))
+  nm <- shared_name(x)
+  y <- x$outer
+  y$a[1] <- 99L
+  expect_identical(y$a[1], 99L)
+  x2 <- map_shared(nm)
+  expect_identical(x2$outer$a[], 1:5)
+})
+
+test_that("is_shared TRUE for sub-lists and nested elements", {
+  x <- share(list(outer = list(a = 1:5, b = letters)))
+  expect_true(is_shared(x))
+  expect_true(is_shared(x$outer))
+  expect_true(is_shared(x$outer$a))
+  expect_true(is_shared(x$outer$b))
+})
+
+test_that("shared_name returns root name for root, blank for sub-lists", {
+  x <- share(list(outer = list(a = 1:5)))
+  nm <- shared_name(x)
+  expect_true(nzchar(nm))
+  expect_identical(shared_name(x$outer), "")
+})
+
+test_that("deeply nested structure (3 list levels) round-trips", {
+  x <- share(list(a = list(b = list(c = 1:5))))
+  y <- map_shared(shared_name(x))
+  expect_identical(y$a$b$c[], 1:5)
+  expect_true(is_shared(y$a$b))
+})
+
+test_that("nested element keeps parent SHM alive through GC", {
+  x <- share(list(outer = list(a = 1:10)))
+  nm <- shared_name(x)
+  deep <- x$outer$a
+  rm(x)
+  gc()
+  y <- map_shared(nm)
+  expect_identical(y$outer$a[], 1:10)
+  expect_identical(deep[], 1:10)
+})
+
+test_that("nested sub-list survives serialize → unserialize round-trip", {
+  x <- share(list(outer = list(a = 1:5, b = 6:10)))
+  sub <- x$outer
+  y <- unserialize(serialize(sub, NULL))
+  expect_identical(y$a[], 1:5)
+  expect_identical(y$b[], 6:10)
+})
+
+test_that("pairlist nested inside a shared list is coerced and accessible", {
+  x <- share(list(outer = pairlist(a = 1L, b = "hi", c = 3:5)))
+  expect_identical(x$outer$a[], 1L)
+  expect_identical(x$outer$b, "hi")
+  expect_identical(x$outer$c[], 3:5)
+  y <- map_shared(shared_name(x))
+  expect_identical(y$outer$a[], 1L)
+  expect_identical(y$outer$b, "hi")
+  expect_identical(y$outer$c[], 3:5)
+})
+
+test_that("depth-3 path serialize → unserialize works", {
+  x <- share(list(a = list(b = list(c = 1:50))))
+  vec <- x$a$b$c
+  y <- unserialize(serialize(vec, NULL))
+  expect_identical(y[], 1:50)
+  sub <- x$a$b
+  y2 <- unserialize(serialize(sub, NULL))
+  expect_identical(y2$c[], 1:50)
+})
+
+test_that("string leaf inside sub-list serialize → unserialize works", {
+  x <- share(list(outer = list(labels = c("alpha", "beta", "gamma"))))
+  s <- x$outer$labels
+  y <- unserialize(serialize(s, NULL))
+  expect_identical(y[], c("alpha", "beta", "gamma"))
+})
+
+test_that("re-serialization of an unserialized nested leaf works", {
+  x <- share(list(a = list(b = list(c = 1:100))))
+  vec <- x$a$b$c
+  y <- unserialize(serialize(vec, NULL))
+  z <- unserialize(serialize(y, NULL))
+  expect_identical(z[], 1:100)
+  sub <- x$a$b
+  y2 <- unserialize(serialize(sub, NULL))
+  z2 <- unserialize(serialize(y2, NULL))
+  expect_identical(z2$c[], 1:100)
+})
+
+test_that("sub-list reference alone keeps root SHM alive through GC", {
+  x <- share(list(outer = list(a = 1:10, b = letters)))
+  nm <- shared_name(x)
+  sub <- x$outer
+  rm(x)
+  gc()
+  y <- map_shared(nm)
+  expect_identical(y$outer$a[], 1:10)
+  expect_identical(sub$a[], 1:10)
+  expect_identical(sub$b, letters)
+})


### PR DESCRIPTION
Closes #1.

## Zero-copy nested lists

Previously, a shared list whose elements were themselves lists (including data frames with list-columns, lists of data frames, or any deeper nesting) round-tripped the inner lists as **serialized bytes** inside the parent SHM. Reading a sub-list materialized it as a plain R list — no SHM backing, no cross-process sharing, not even `is_shared() == TRUE`.

After this PR, every level of nesting is zero-copy. A list-of-lists-of-data-frames is one SHM region, and every level is an ALTLIST on the consumer.

### What changes for users

```r
x <- share(list(outer = list(a = 1:100, df = data.frame(v = 1:10))))
y <- map_shared(shared_name(x))

is_shared(y$outer)        # TRUE  (was: FALSE)
is_shared(y$outer$a)      # TRUE  (was: FALSE — it was a plain integer vector)
is_shared(y$outer$df)     # TRUE  (was: FALSE)
shared_name(y$outer)      # ""   — sub-lists have no standalone name
shared_name(y)            # "/mori_..." — only the root has one
```

Sending a *sub-list* or a nested column through `mirai` (or any serializer) now produces the same ~30-byte `(name, path)` reference that top-level shared objects already used — no bulk re-serialization, no new SHM.

### On-disk format

A nested VECSXP element is written inline as a **complete child MORL region** at its `data_offset` — same header / directory / attrs layout the root already used, just recursively. The parent's directory entry uses `sexptype == VECSXP` and its `attrs_size` is always 0 (child attrs live inside the child region).

Old blobs with no nesting remain readable: a length-1 integer path on the wire is identical to the previous scalar-int form.

### In-memory model

Consumers now wrap each MORL level in a lightweight `mori_list_view { base, region_size, n_elements, index }` rather than a full `mori_shm`. Sub-list ALTLISTs chain up through the extptr `prot` slot: leaf → parent view(s) → root shm extptr → host extptr. Holding any descendant keeps the root SHM mapped.

Serialization walks that chain: `mori_build_path` collects view indices up to the root, producing `list(root_name, integer_path)`. Unserialization (`mori_open_path`) opens the root SHM and walks the path one MORL level at a time, bounds-checking each child region against its parent. Two extptr tags (`mori_shm_tag`, `mori_view_tag`) disambiguate the addr type so identity helpers stay O(1).

### COW and GC

- `sub[[k]] <- ...` on a shared sub-list duplicates just that sub-list into a plain VECSXP, leaving the parent SHM untouched.
- Keeping any leaf or sub-list alive keeps the root SHM mapped, even after the enclosing ALTLISTs are GC'd.

### Tests

22 new tests in `test-nested.R` + 1 in `test-list.R`. 239 total (was 179). Coverage includes: list-columns, lists of data frames, classed/named/factor sub-lists, empty and NULL sub-lists, pairlist at depth, depth-3 paths through serialize/unserialize, STRSXP leaves in sub-lists, re-serialization of an unserialized leaf, sub-list COW, sub-list-only GC lifetime, `is_shared`/`shared_name` semantics. Integration-tested through a `mirai` daemon round-trip.

### Compatibility

- Public API unchanged.
- Wire format for existing top-level shared objects and direct list-element references is byte-identical.
- Flat lists (no VECSXP children) produce a MORL region of the same size and layout as before.

## Test plan

- [x] `devtools::test()` — 239 PASS, 0 FAIL
- [x] `R CMD check` — clean (only a pre-existing clang warning from an R header)
- [x] Cross-process round-trip through a `mirai` daemon