### PR TITLE
Make share() idempotent on already-shared objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ devtools::document()
 
 All R exported functions are single `.Call` wrappers. `share()` calls `mori_create` which dispatches on `TYPEOF(x)`:
 
+0. If `x` is already a mori-backed ALTREP (detected via the `mori_owned_tag` on `R_altrep_data1(x)`), return `x` unchanged. This makes `share()` idempotent and also short-circuits re-sharing of sub-list views and element vectors extracted from an ALTLIST.
 1. `NILSXP` → returned as-is (falls through all checks).
 2. `VECSXP`/`LISTSXP` → `mori_shm_create_list_call` — ALTLIST with per-element directory. Writing is split into two passes: `mori_nested_size` computes the total SHM size (recursing into nested VECSXP/LISTSXP elements), and `mori_nested_write` produces a complete MORL region at the target base pointer, recursing into child VECSXP/LISTSXP elements by calling itself on `base + child_data_offset`. Each element is independently zero-copy (any atomic, with or without attributes), serialized as bytes, or a nested MORL region. Data frames and pairlists go through this path (pairlists are coerced to VECSXP via `Rf_coerceVector`, both at the top level and at each level of the recursion).
 3. `STRSXP` → `mori_shm_create_string_call` — ALTSTRING backed by SHM with offset table + packed string data. Attributes (if any) are serialized after the string data.

--- a/R/share.R
+++ b/R/share.R
@@ -25,6 +25,10 @@
 #' referenced in R, and is freed by the garbage collector when no
 #' references remain.
 #'
+#' `share()` is idempotent: calling it on an object that is already
+#' backed by shared memory returns the input unchanged without
+#' allocating a new region.
+#'
 #' **Important**: always assign the result of `share()` to a
 #' variable. The shared memory is kept alive by the R object reference —
 #' if the result is used as a temporary (not assigned), the garbage

--- a/man/share.Rd
+++ b/man/share.Rd
@@ -34,6 +34,10 @@ long as the returned object (or any element extracted from it) is
 referenced in R, and is freed by the garbage collector when no
 references remain.
 
+\code{share()} is idempotent: calling it on an object that is already
+backed by shared memory returns the input unchanged without
+allocating a new region.
+
 \strong{Important}: always assign the result of \code{share()} to a
 variable. The shared memory is kept alive by the R object reference —
 if the result is used as a temporary (not assigned), the garbage

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -812,6 +812,11 @@ static SEXP mori_shm_create_string_call(SEXP x) {
 
 /* Unified entry point: dispatch by type */
 SEXP mori_create(SEXP x) {
+  if (ALTREP(x)) {
+    SEXP d1 = R_altrep_data1(x);
+    if (TYPEOF(d1) == EXTPTRSXP && R_ExternalPtrTag(d1) == mori_owned_tag)
+      return x;
+  }
   int type = TYPEOF(x);
   if (type == VECSXP || type == LISTSXP)
     return mori_shm_create_list_call(x);

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -113,6 +113,30 @@ test_that("shared_name returns '' for a sub-list", {
   expect_identical(shared_name(sub), "")
 })
 
+test_that("share() is idempotent on already-shared objects", {
+  x <- share(as.double(1:100))
+  expect_identical(share(x), x)
+  expect_identical(shared_name(share(x)), shared_name(x))
+
+  s <- share(letters)
+  expect_identical(share(s), s)
+  expect_identical(shared_name(share(s)), shared_name(s))
+
+  L <- share(list(a = 1:3, b = c("x", "y")))
+  expect_identical(share(L), L)
+  expect_identical(shared_name(share(L)), shared_name(L))
+
+  y <- map_shared(shared_name(x))
+  expect_identical(share(y), y)
+  expect_identical(shared_name(share(y)), shared_name(y))
+
+  root <- share(list(v = 1:10, sub = list(a = 1:5, s = letters)))
+  sub <- root[[2L]]
+  expect_identical(share(sub), sub)
+  elt <- root[[1L]]
+  expect_identical(share(elt), elt)
+})
+
 test_that("is_shared/shared_name preserved after COW materialization", {
   x <- share(as.double(1:10))
   nm <- shared_name(x)


### PR DESCRIPTION
## Summary
Calling `share()` on an object already backed by shared memory now returns the input unchanged instead of allocating a fresh SHM region.

## Motivation
Previously `mori_create` dispatched purely on `TYPEOF(x)`, so `share(share(x))`, `share(map_shared(nm))`, and re-sharing of sub-list views or extracted element vectors each allocated a new SHM region — doubling memory use and producing a different `shared_name()` on every call.

## Change
In `src/altrep.c` (`mori_create`), short-circuit at the top: if `x` is ALTREP and its `data1` extptr carries `mori_owned_tag`, return `x` as-is. This covers root-shared objects, sub-list views, and element vectors uniformly — all three already live in shared memory via the keeper chain.

## Test plan
- [x] New `share() is idempotent on already-shared objects` in `tests/testthat/test-api.R` — verifies object identity and `shared_name()` stability across atomic / string / list / `map_shared` result / sub-list / element vector
- [x] Full `devtools::test()` suite: 274 / 274 pass