### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,6 +2,7 @@
 ^\.git$
 ^\.gitignore$
 ^\.claude$
+^\.cache$
 ^README\.Rmd$
 ^\.github$
 ^CLAUDE\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ compile_commands.json
 docs/
 # Claude Code
 .claude/
+.cache/
 # OS
 .DS_Store

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -283,12 +283,13 @@ static void *mori_vec_Dataptr(SEXP x, Rboolean writable) {
   if (!writable)
     return (void *) v->data;
 
-  /* COW: materialize to a regular R vector */
+  /* COW: materialize to a regular R vector. Attributes live on the ALTREP
+     wrapper x, not on data2 — no method reads data2's attrs, and R's
+     ALTREP serialize reapplies ATTRIB(x) on top of the unserialized state. */
   R_xlen_t n = v->length;
   int type = TYPEOF(x);
   SEXP mat = PROTECT(Rf_allocVector(type, n));
   memcpy(mori_data_ptr(mat), v->data, (size_t) n * mori_sizeof_elt(type));
-  DUPLICATE_ATTRIB(mat, x);
   R_set_altrep_data2(x, mat);
   UNPROTECT(1);
 

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -453,9 +453,9 @@ static SEXP mori_unwrap_element(unsigned char *base, int64_t region_size,
   memcpy(&length, dir + 24, 8);
 
   if (mori_oob(data_offset, data_size, region_size))
-    Rf_error("mori: element data out of bounds");
+    Rf_error("mori: invalid element data");
   if (attrs_size > 0 && attrs_size > data_size)
-    Rf_error("mori: element attrs size larger than data");
+    Rf_error("mori: invalid element data");
 
   SEXP result;
   if (sexptype == VECSXP) {
@@ -514,12 +514,12 @@ static SEXP mori_make_view_extptr(unsigned char *base, int64_t region_size,
                                   int32_t index, SEXP keeper) {
 
   if (region_size < 24)
-    Rf_error("mori: nested list region too small");
+    Rf_error("mori: invalid nested list region");
 
   uint32_t magic;
   memcpy(&magic, base, 4);
   if (magic != 0x4D4F524Cu)
-    Rf_error("mori: invalid nested list magic bytes");
+    Rf_error("mori: invalid nested list region");
 
   int32_t n;
   int64_t attrs_offset, attrs_size;
@@ -527,10 +527,9 @@ static SEXP mori_make_view_extptr(unsigned char *base, int64_t region_size,
   memcpy(&attrs_offset, base + 8, 8);
   memcpy(&attrs_size, base + 16, 8);
 
-  if (n < 0 || (int64_t) 24 + (int64_t) 32 * n > region_size)
-    Rf_error("mori: nested list directory out of bounds");
-  if (mori_oob(attrs_offset, attrs_size, region_size))
-    Rf_error("mori: nested list attrs out of bounds");
+  if (n < 0 || n > (region_size - 24) / 32 ||
+      mori_oob(attrs_offset, attrs_size, region_size))
+    Rf_error("mori: invalid nested list region");
 
   mori_list_view *v = malloc(sizeof(mori_list_view));
   if (!v) Rf_error("mori: allocation failure");
@@ -1011,18 +1010,27 @@ static SEXP mori_open_vector(SEXP shm_ptr) {
 
   mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
   unsigned char *base = (unsigned char *) shm->addr;
+  int64_t shm_size = (int64_t) shm->size;
   int32_t sexptype;
   int64_t length, attrs_size;
+  if (shm_size < 64)
+    Rf_error("mori: invalid vector region");
   memcpy(&sexptype, base + 4, 4);
   memcpy(&length, base + 8, 8);
   memcpy(&attrs_size, base + 16, 8);
+
+  size_t elt_size = mori_sizeof_elt(sexptype);
+  if (elt_size == 0 || length < 0 || attrs_size < 0 ||
+      attrs_size > shm_size - 64 ||
+      length > (shm_size - 64 - attrs_size) / (int64_t) elt_size)
+    Rf_error("mori: invalid vector region");
 
   SEXP result = PROTECT(mori_make_vector(
     base + 64, (R_xlen_t) length, sexptype, shm_ptr
   ));
 
   if (attrs_size > 0) {
-    size_t data_bytes = (size_t) length * mori_sizeof_elt(sexptype);
+    size_t data_bytes = (size_t) length * elt_size;
     mori_restore_attrs(result, base + 64 + data_bytes, (size_t) attrs_size);
   }
 
@@ -1034,11 +1042,20 @@ static SEXP mori_open_string(SEXP shm_ptr) {
 
   mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
   unsigned char *base = (unsigned char *) shm->addr;
+  int64_t shm_size = (int64_t) shm->size;
   int32_t attrs_size;
   int64_t n, str_data_size;
+  if (shm_size < 24)
+    Rf_error("mori: invalid string region");
   memcpy(&attrs_size, base + 4, 4);
   memcpy(&n, base + 8, 8);
   memcpy(&str_data_size, base + 16, 8);
+
+  if (n < 0 || str_data_size < 0 || attrs_size < 0 ||
+      str_data_size > shm_size - 24 ||
+      attrs_size > shm_size - 24 - str_data_size ||
+      n > str_data_size / 16)
+    Rf_error("mori: invalid string region");
 
   SEXP result = PROTECT(mori_make_string(
     base + 24, (R_xlen_t) n, shm_ptr
@@ -1228,7 +1245,7 @@ static SEXP mori_open_path_c(const char *name,
   uint32_t magic;
   memcpy(&magic, base, 4);
   if (magic != 0x4D4F524Cu)
-    Rf_error("mori: not a list region");  /* GC reclaims shm_ptr via longjmp */
+    Rf_error("mori: invalid nested list region");  /* GC reclaims shm_ptr via longjmp */
 
   SEXP keeper = shm_ptr;
   unsigned char *cur_base = base;
@@ -1255,7 +1272,7 @@ static SEXP mori_open_path_c(const char *name,
     if (sexptype != VECSXP)
       Rf_error("mori: path step is not a nested list");
     if (mori_oob(data_offset, data_size, cur_region_size))
-      Rf_error("mori: nested region out of bounds");
+      Rf_error("mori: invalid nested region");
 
     /* Bare extptr: no ALTLIST wrapper, no attr restore (intermediate is
        never observed; only its index in the keeper chain matters). */

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -1010,27 +1010,18 @@ static SEXP mori_open_vector(SEXP shm_ptr) {
 
   mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
   unsigned char *base = (unsigned char *) shm->addr;
-  int64_t shm_size = (int64_t) shm->size;
   int32_t sexptype;
   int64_t length, attrs_size;
-  if (shm_size < 64)
-    Rf_error("mori: invalid vector region");
   memcpy(&sexptype, base + 4, 4);
   memcpy(&length, base + 8, 8);
   memcpy(&attrs_size, base + 16, 8);
-
-  size_t elt_size = mori_sizeof_elt(sexptype);
-  if (elt_size == 0 || length < 0 || attrs_size < 0 ||
-      attrs_size > shm_size - 64 ||
-      length > (shm_size - 64 - attrs_size) / (int64_t) elt_size)
-    Rf_error("mori: invalid vector region");
 
   SEXP result = PROTECT(mori_make_vector(
     base + 64, (R_xlen_t) length, sexptype, shm_ptr
   ));
 
   if (attrs_size > 0) {
-    size_t data_bytes = (size_t) length * elt_size;
+    size_t data_bytes = (size_t) length * mori_sizeof_elt(sexptype);
     mori_restore_attrs(result, base + 64 + data_bytes, (size_t) attrs_size);
   }
 
@@ -1042,20 +1033,11 @@ static SEXP mori_open_string(SEXP shm_ptr) {
 
   mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(shm_ptr);
   unsigned char *base = (unsigned char *) shm->addr;
-  int64_t shm_size = (int64_t) shm->size;
   int32_t attrs_size;
   int64_t n, str_data_size;
-  if (shm_size < 24)
-    Rf_error("mori: invalid string region");
   memcpy(&attrs_size, base + 4, 4);
   memcpy(&n, base + 8, 8);
   memcpy(&str_data_size, base + 16, 8);
-
-  if (n < 0 || str_data_size < 0 || attrs_size < 0 ||
-      str_data_size > shm_size - 24 ||
-      attrs_size > shm_size - 24 - str_data_size ||
-      n > str_data_size / 16)
-    Rf_error("mori: invalid string region");
 
   SEXP result = PROTECT(mori_make_string(
     base + 24, (R_xlen_t) n, shm_ptr

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -448,7 +448,7 @@ static SEXP mori_unwrap_element(unsigned char *base, int64_t region_size,
 
   /* Bounds-check the data region against the enclosing region */
   if (data_offset < 0 || data_size < 0 ||
-      data_offset + data_size > region_size)
+      data_offset > region_size - data_size)
     Rf_error("mori: element data out of bounds");
   if (attrs_size > 0 && attrs_size > data_size)
     Rf_error("mori: element attrs size larger than data");
@@ -526,7 +526,7 @@ static SEXP mori_make_view_extptr(unsigned char *base, int64_t region_size,
   if (n < 0 || (int64_t) 24 + (int64_t) 32 * n > region_size)
     Rf_error("mori: nested list directory out of bounds");
   if (attrs_offset < 0 || attrs_size < 0 ||
-      attrs_offset + attrs_size > region_size)
+      attrs_offset > region_size - attrs_size)
     Rf_error("mori: nested list attrs out of bounds");
 
   mori_list_view *v = malloc(sizeof(mori_list_view));
@@ -1252,7 +1252,7 @@ static SEXP mori_open_path_c(const char *name,
     if (sexptype != VECSXP)
       Rf_error("mori: path step is not a nested list");
     if (data_offset < 0 || data_size < 0 ||
-        data_offset + data_size > cur_region_size)
+        data_offset > cur_region_size - data_size)
       Rf_error("mori: nested region out of bounds");
 
     /* Bare extptr: no ALTLIST wrapper, no attr restore (intermediate is

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -45,6 +45,12 @@ static inline void *mori_data_ptr(SEXP x) {
   }
 }
 
+// Bounds check for a [offset, offset+size) chunk within a region -------------
+
+static inline int mori_oob(int64_t offset, int64_t size, int64_t region_size) {
+  return offset < 0 || size < 0 || offset > region_size - size;
+}
+
 // Attribute helpers for API compliance ----------------------------------------
 
 /* Named list on R >= 4.6.0, pairlist otherwise. R_NilValue if none.
@@ -446,9 +452,7 @@ static SEXP mori_unwrap_element(unsigned char *base, int64_t region_size,
   memcpy(&attrs_size, dir + 20, 4);
   memcpy(&length, dir + 24, 8);
 
-  /* Bounds-check the data region against the enclosing region */
-  if (data_offset < 0 || data_size < 0 ||
-      data_offset > region_size - data_size)
+  if (mori_oob(data_offset, data_size, region_size))
     Rf_error("mori: element data out of bounds");
   if (attrs_size > 0 && attrs_size > data_size)
     Rf_error("mori: element attrs size larger than data");
@@ -525,8 +529,7 @@ static SEXP mori_make_view_extptr(unsigned char *base, int64_t region_size,
 
   if (n < 0 || (int64_t) 24 + (int64_t) 32 * n > region_size)
     Rf_error("mori: nested list directory out of bounds");
-  if (attrs_offset < 0 || attrs_size < 0 ||
-      attrs_offset > region_size - attrs_size)
+  if (mori_oob(attrs_offset, attrs_size, region_size))
     Rf_error("mori: nested list attrs out of bounds");
 
   mori_list_view *v = malloc(sizeof(mori_list_view));
@@ -1251,8 +1254,7 @@ static SEXP mori_open_path_c(const char *name,
 
     if (sexptype != VECSXP)
       Rf_error("mori: path step is not a nested list");
-    if (data_offset < 0 || data_size < 0 ||
-        data_offset > cur_region_size - data_size)
+    if (mori_oob(data_offset, data_size, cur_region_size))
       Rf_error("mori: nested region out of bounds");
 
     /* Bare extptr: no ALTLIST wrapper, no attr restore (intermediate is

--- a/src/shm.c
+++ b/src/shm.c
@@ -261,7 +261,10 @@ mori_shm *mori_shm_open_heap(const char *name) {
 
 // Platform-independent finalizers --------------------------------------------
 
-/* Daemon-side finalizer: unmap only, don't unlink (host manages lifetime) */
+/* Mapping finalizer (both sides): releases this side's mapping only.
+   The name (POSIX) / creator handle (Windows) is released independently
+   by mori_host_finalizer on the chained host_tag extptr — so a consumer
+   keeps reading after the host is GC'd. */
 void mori_shm_finalizer(SEXP ptr) {
   mori_shm *shm = (mori_shm *) R_ExternalPtrAddr(ptr);
   if (shm) {

--- a/tests/testthat/test-cow.R
+++ b/tests/testthat/test-cow.R
@@ -29,3 +29,28 @@ test_that("sum on materialized vector uses the private copy", {
   x[1] <- 999
   expect_equal(sum(x), 999 + sum(2:100))
 })
+
+test_that("attributes survive COW materialization on atomic ALTREP", {
+  # Attributes live on the ALTREP wrapper, not on data2 — verify the
+  # wrapper-side attrs remain visible after a write triggers materialization.
+  x <- share(c(a = 1, b = 2, c = 3))
+  x[1] <- 99
+  expect_identical(names(x), c("a", "b", "c"))
+
+  m <- share(matrix(as.double(1:12), nrow = 3))
+  m[1, 1] <- 999
+  expect_identical(dim(m), c(3L, 4L))
+
+  f <- share(factor(c("a", "b", "c", "a")))
+  f[1] <- "b"
+  expect_s3_class(f, "factor")
+  expect_identical(levels(f), c("a", "b", "c"))
+})
+
+test_that("attributes survive serialize round-trip after COW", {
+  x <- share(c(a = 1, b = 2, c = 3))
+  x[1] <- 99
+  y <- unserialize(serialize(x, NULL))
+  expect_identical(names(y), c("a", "b", "c"))
+  expect_equal(unname(y), c(99, 2, 3))
+})


### PR DESCRIPTION
- Rewrite chunk-fits bounds checks to avoid signed-int64 overflow UB.                   
- Standardise error messages: `invalid X region` for corruption, `out of bounds` for user-supplied path indices.                                   
- Drop dead `DUPLICATE_ATTRIB` in `mori_string_Dataptr`; ALTREP attrs live on the wrapper, not `data2`.