### PR TITLE
Change return value of invalid input to `shared_name()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `shared_name()` and `map_shared()` now round-trip for sub-lists and extracted elements, not just whole shared objects. Sub-object identifiers carry a bracketed index path (e.g. `/mori_abc_1[2,3]`).
 * Wire-format change (breaking): The serialization format and the shared memory region naming scheme have both changed.
+* `shared_name()` now returns `NULL` for non-shared inputs (previously the empty string `""`); `shared_name(x) %||% ""` retains the previous behaviour.
 * `share()` on Linux fails with a clean R error when `/dev/shm` is too small (typical in containers, where the limit can be raised at start) instead of SIGBUS-ing mid-serialize (#14).
 * `map_shared()` on Linux no longer prefaults the whole region, restoring lazy first-touch access to match macOS.
 

--- a/R/share.R
+++ b/R/share.R
@@ -9,38 +9,35 @@
 #'   attributes such as names, dim, class, or levels) and lists or data
 #'   frames whose elements are such vectors, an ALTREP-backed object that
 #'   reads directly from shared memory. For any other object (environments,
-#'   closures, language objects, `NULL`), the input is returned
-#'   unchanged with no shared memory region created.
+#'   closures, language objects, `NULL`), the input is returned unchanged
+#'   with no shared memory region created.
 #'
 #' @details
-#' Attributes are stored alongside the data in the shared memory region
-#' and restored on the consumer side. Character vectors use a packed
-#' layout and elements are materialised lazily on access. When serialised
-#' (e.g. by [serialize()] or across a `mirai()` call), a
-#' shared object is represented compactly by its SHM name (~30 bytes)
-#' rather than by its contents.
+#' Attributes are stored alongside the data in the shared memory region and
+#' restored on the consumer side. Character vectors use a packed layout and
+#' elements are materialised lazily on access. When serialised (e.g. by
+#' [serialize()] or across a `mirai()` call), a shared object is represented
+#' compactly by its shared memory name (~30 bytes) rather than by its
+#' contents.
 #'
-#' The shared memory region is managed automatically. It stays alive as
-#' long as the returned object (or any element extracted from it) is
-#' referenced in R, and is freed by the garbage collector when no
-#' references remain.
+#' The shared memory region is managed automatically. It stays alive as long
+#' as the returned object (or any element extracted from it) is referenced
+#' in R, and is freed by the garbage collector when no references remain.
 #'
-#' `share()` is idempotent: calling it on an object that is already
-#' backed by shared memory returns the input unchanged without
-#' allocating a new region.
+#' `share()` is idempotent: calling it on an object that is already backed by
+#' shared memory returns the input unchanged without allocating a new region.
 #'
-#' **Important**: always assign the result of `share()` to a
-#' variable. The shared memory is kept alive by the R object reference —
-#' if the result is used as a temporary (not assigned), the garbage
-#' collector may free the shared memory before a consumer process has
-#' mapped it.
+#' **Important**: always assign the result of `share()` to a variable. The
+#' shared memory is kept alive by the R object reference — if the result is
+#' used as a temporary (not assigned), the garbage collector may free the
+#' shared memory before a consumer process has mapped it.
 #'
 #' @section Persistence:
-#' Direct [saveRDS()] of a shared object writes only the SHM name, so
-#' the resulting file is meaningful only on the same machine while the
-#' region is still alive. For portable storage or transport across
-#' machines, materialise into a regular in-memory copy first with
-#' `rlang::duplicate()`, which deep-duplicates the object:
+#' Direct [saveRDS()] of a shared object writes only the shared memory name,
+#' so the resulting file is meaningful only on the same machine while the
+#' region is still alive. For portable storage or transport across machines,
+#' materialise into a regular in-memory copy first with `rlang::duplicate()`,
+#' which deep-duplicates the object:
 #'
 #' ```r
 #' saveRDS(rlang::duplicate(x), file = "x.rds")
@@ -51,7 +48,7 @@
 #' sum(x)
 #'
 #' @seealso [map_shared()] to open a shared region by name,
-#'   [shared_name()] to extract the SHM name.
+#'   [shared_name()] to extract the shared memory name.
 #'
 #' @export
 share <- function(x) .Call(mori_create, x)
@@ -61,18 +58,17 @@ share <- function(x) .Call(mori_create, x)
 #' Open a shared memory region identified by a name string and return an
 #' ALTREP-backed R object that reads directly from shared memory.
 #'
-#' @param name a character string identifier as returned by
-#'   [shared_name()]: either a bare SHM region name (opens the root) or a
-#'   region name with a 1-based bracketed index path (e.g.
-#'   `"/mori_abc_1[2,3]"`, opens the addressed sub-list or element
-#'   directly).
+#' @param name a character string as returned by [shared_name()]: either a
+#'   bare shared memory name (opens the root) or a name with a 1-based
+#'   bracketed index path (e.g. `"/mori_abc_1[2,3]"`, opens the addressed
+#'   sub-list or element directly).
 #'
 #' @return The R object stored at the named region (or sub-object at the
-#'   given path), or `NULL` if `name` is not a valid shared memory
-#'   identifier (wrong type, length, `NA`, missing or malformed prefix,
-#'   or malformed bracketed path). If `name` parses as a valid identifier
-#'   but the region is absent or corrupted — or the path indexes out of
-#'   bounds or through a non-list step — an error is raised.
+#'   given path), or `NULL` if `name` is not a valid shared memory name
+#'   (wrong type, length, `NA`, missing or malformed prefix, or malformed
+#'   bracketed path). If `name` parses as valid but the region is absent or
+#'   corrupted — or the path doesn't address a valid sub-object — an error
+#'   is raised.
 #'
 #' @examples
 #' x <- share(1:100)
@@ -80,8 +76,8 @@ share <- function(x) .Call(mori_create, x)
 #' y <- map_shared(nm)
 #' sum(y)
 #'
-#' @seealso [share()] to create a shared object, [shared_name()] to
-#'   extract the name.
+#' @seealso [share()] to create a shared object, [shared_name()] to extract
+#'   the shared memory name.
 #'
 #' @export
 map_shared <- function(name) .Call(mori_shm_open_and_wrap, name)
@@ -105,17 +101,17 @@ is_shared <- function(x) .Call(mori_is_shared, x)
 
 #' Extract Shared Memory Name
 #'
-#' Extract the SHM region name from a shared object. This name can be
+#' Extract the shared memory name from a shared object. This name can be
 #' passed to [map_shared()] to open the same region in another process.
 #'
 #' @param x a shared object as returned by [share()] or [map_shared()].
 #'
-#' @return A character string identifying the shared object, or `NULL`
-#'   if `x` is not a shared object. For a sub-list or element extracted
-#'   from a shared list, the string carries a bracketed 1-based index
-#'   path (e.g. `"/mori_abc_1[2,3]"`). [map_shared()] accepts both
-#'   forms; the path-bearing form returns the addressed sub-object directly.
-#'   The OS-level SHM region name is the prefix before `[` and is
+#' @return A character string identifying the shared object, or `NULL` if
+#'   `x` is not a shared object. For a sub-list or element extracted from a
+#'   shared list, the string carries a bracketed 1-based index path (e.g.
+#'   `"/mori_abc_1[2,3]"`). [map_shared()] accepts both forms; the
+#'   path-qualified form returns the addressed sub-object directly. The
+#'   underlying shared memory region name is the prefix before `[` and is
 #'   recoverable via `sub("\\[.*$", "", shared_name(x))`.
 #'
 #' @examples

--- a/R/share.R
+++ b/R/share.R
@@ -110,10 +110,10 @@ is_shared <- function(x) .Call(mori_is_shared, x)
 #'
 #' @param x a shared object as returned by [share()] or [map_shared()].
 #'
-#' @return A character string identifying the shared object, or the empty
-#'   string `""` if `x` is not a shared object. For a sub-list or element
-#'   extracted from a shared list, the string carries a bracketed 1-based
-#'   index path (e.g. `"/mori_abc_1[2,3]"`). [map_shared()] accepts both
+#' @return A character string identifying the shared object, or `NULL`
+#'   if `x` is not a shared object. For a sub-list or element extracted
+#'   from a shared list, the string carries a bracketed 1-based index
+#'   path (e.g. `"/mori_abc_1[2,3]"`). [map_shared()] accepts both
 #'   forms; the path-bearing form returns the addressed sub-object directly.
 #'   The OS-level SHM region name is the prefix before `[` and is
 #'   recoverable via `sub("\\[.*$", "", shared_name(x))`.

--- a/README.Rmd
+++ b/README.Rmd
@@ -101,7 +101,7 @@ Workers must run on the same machine — mori shares physical RAM, not bytes ove
 
 ### Sharing by name
 
-`shared_name()` returns the SHM identifier of a shared object; `map_shared()` opens a region by that name — useful for handing a reference between processes without going through serialization:
+`shared_name()` returns the shared memory name of a shared object; `map_shared()` opens a region by that name — useful for handing a reference between processes without going through serialization:
 
 ```{r}
 #| label: by-name
@@ -165,7 +165,7 @@ shared_name(df[[50]])  # sub-path into the same region
 ### Lifetime
 
 Shared memory is managed by R's garbage collector.
-The SHM region stays alive as long as any shared object backed by it remains referenced in R — the original returned by `share()`, or a column or sub-list extracted from it, in this or another process.
+The shared memory region stays alive as long as any shared object backed by it remains referenced in R — the original returned by `share()`, or a column or sub-list extracted from it, in this or another process.
 When no references remain, the garbage collector frees the shared memory automatically.
 
 **Important:** Always assign the result of `share()` to a variable.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ bytes over a network.
 
 ### Sharing by name
 
-`shared_name()` returns the SHM identifier of a shared object;
+`shared_name()` returns the shared memory name of a shared object;
 `map_shared()` opens a region by that name — useful for handing a
 reference between processes without going through serialization:
 
@@ -111,7 +111,7 @@ reference between processes without going through serialization:
 x <- share(rnorm(1e6))
 
 shared_name(x)
-#> [1] "/mori_abda_1"
+#> [1] "/mori_4d1b_1"
 
 # Another process — here the same one — can map the region by name
 y <- map_shared(shared_name(x))
@@ -144,7 +144,7 @@ lst <- share(list(a = rnorm(1e6), b = rnorm(1e6), c = rnorm(1e6)))
 
 # Each element arrives on the worker as a zero-copy reference
 mirai_map(lst, \(v) format(lobstr::obj_size(v)))[.flat] |> unique()
-#> [1] "840 B"
+#> [1] "904 B"
 
 daemons(0)
 ```
@@ -170,18 +170,19 @@ strings are accessed lazily per element.
 ``` r
 df <- share(as.data.frame(matrix(rnorm(1e7), ncol = 100)))
 shared_name(df)        # one region for all 100 columns
-#> [1] "/mori_abda_3"
+#> [1] "/mori_4d1b_3"
 shared_name(df[[50]])  # sub-path into the same region
-#> [1] "/mori_abda_3[50]"
+#> [1] "/mori_4d1b_3[50]"
 ```
 
 ### Lifetime
 
-Shared memory is managed by R’s garbage collector. The SHM region stays
-alive as long as any shared object backed by it remains referenced in R
-— the original returned by `share()`, or a column or sub-list extracted
-from it, in this or another process. When no references remain, the
-garbage collector frees the shared memory automatically.
+Shared memory is managed by R’s garbage collector. The shared memory
+region stays alive as long as any shared object backed by it remains
+referenced in R — the original returned by `share()`, or a column or
+sub-list extracted from it, in this or another process. When no
+references remain, the garbage collector frees the shared memory
+automatically.
 
 **Important:** Always assign the result of `share()` to a variable. The
 shared memory is kept alive by the R object reference — if the result is

--- a/man/map_shared.Rd
+++ b/man/map_shared.Rd
@@ -7,19 +7,18 @@
 map_shared(name)
 }
 \arguments{
-\item{name}{a character string identifier as returned by
-\code{\link[=shared_name]{shared_name()}}: either a bare SHM region name (opens the root) or a
-region name with a 1-based bracketed index path (e.g.
-\code{"/mori_abc_1[2,3]"}, opens the addressed sub-list or element
-directly).}
+\item{name}{a character string as returned by \code{\link[=shared_name]{shared_name()}}: either a
+bare shared memory name (opens the root) or a name with a 1-based
+bracketed index path (e.g. \code{"/mori_abc_1[2,3]"}, opens the addressed
+sub-list or element directly).}
 }
 \value{
 The R object stored at the named region (or sub-object at the
-given path), or \code{NULL} if \code{name} is not a valid shared memory
-identifier (wrong type, length, \code{NA}, missing or malformed prefix,
-or malformed bracketed path). If \code{name} parses as a valid identifier
-but the region is absent or corrupted — or the path indexes out of
-bounds or through a non-list step — an error is raised.
+given path), or \code{NULL} if \code{name} is not a valid shared memory name
+(wrong type, length, \code{NA}, missing or malformed prefix, or malformed
+bracketed path). If \code{name} parses as valid but the region is absent or
+corrupted — or the path doesn't address a valid sub-object — an error
+is raised.
 }
 \description{
 Open a shared memory region identified by a name string and return an
@@ -33,6 +32,6 @@ sum(y)
 
 }
 \seealso{
-\code{\link[=share]{share()}} to create a shared object, \code{\link[=shared_name]{shared_name()}} to
-extract the name.
+\code{\link[=share]{share()}} to create a shared object, \code{\link[=shared_name]{shared_name()}} to extract
+the shared memory name.
 }

--- a/man/share.Rd
+++ b/man/share.Rd
@@ -14,43 +14,40 @@ For atomic vectors (including character vectors and those with
 attributes such as names, dim, class, or levels) and lists or data
 frames whose elements are such vectors, an ALTREP-backed object that
 reads directly from shared memory. For any other object (environments,
-closures, language objects, \code{NULL}), the input is returned
-unchanged with no shared memory region created.
+closures, language objects, \code{NULL}), the input is returned unchanged
+with no shared memory region created.
 }
 \description{
 Write an R object into shared memory and return a version that other
 processes on the same machine can map without copying.
 }
 \details{
-Attributes are stored alongside the data in the shared memory region
-and restored on the consumer side. Character vectors use a packed
-layout and elements are materialised lazily on access. When serialised
-(e.g. by \code{\link[=serialize]{serialize()}} or across a \code{mirai()} call), a
-shared object is represented compactly by its SHM name (~30 bytes)
-rather than by its contents.
+Attributes are stored alongside the data in the shared memory region and
+restored on the consumer side. Character vectors use a packed layout and
+elements are materialised lazily on access. When serialised (e.g. by
+\code{\link[=serialize]{serialize()}} or across a \code{mirai()} call), a shared object is represented
+compactly by its shared memory name (~30 bytes) rather than by its
+contents.
 
-The shared memory region is managed automatically. It stays alive as
-long as the returned object (or any element extracted from it) is
-referenced in R, and is freed by the garbage collector when no
-references remain.
+The shared memory region is managed automatically. It stays alive as long
+as the returned object (or any element extracted from it) is referenced
+in R, and is freed by the garbage collector when no references remain.
 
-\code{share()} is idempotent: calling it on an object that is already
-backed by shared memory returns the input unchanged without
-allocating a new region.
+\code{share()} is idempotent: calling it on an object that is already backed by
+shared memory returns the input unchanged without allocating a new region.
 
-\strong{Important}: always assign the result of \code{share()} to a
-variable. The shared memory is kept alive by the R object reference —
-if the result is used as a temporary (not assigned), the garbage
-collector may free the shared memory before a consumer process has
-mapped it.
+\strong{Important}: always assign the result of \code{share()} to a variable. The
+shared memory is kept alive by the R object reference — if the result is
+used as a temporary (not assigned), the garbage collector may free the
+shared memory before a consumer process has mapped it.
 }
 \section{Persistence}{
 
-Direct \code{\link[=saveRDS]{saveRDS()}} of a shared object writes only the SHM name, so
-the resulting file is meaningful only on the same machine while the
-region is still alive. For portable storage or transport across
-machines, materialise into a regular in-memory copy first with
-\code{rlang::duplicate()}, which deep-duplicates the object:
+Direct \code{\link[=saveRDS]{saveRDS()}} of a shared object writes only the shared memory name,
+so the resulting file is meaningful only on the same machine while the
+region is still alive. For portable storage or transport across machines,
+materialise into a regular in-memory copy first with \code{rlang::duplicate()},
+which deep-duplicates the object:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{saveRDS(rlang::duplicate(x), file = "x.rds")
 }\if{html}{\out{</div>}}
@@ -63,5 +60,5 @@ sum(x)
 }
 \seealso{
 \code{\link[=map_shared]{map_shared()}} to open a shared region by name,
-\code{\link[=shared_name]{shared_name()}} to extract the SHM name.
+\code{\link[=shared_name]{shared_name()}} to extract the shared memory name.
 }

--- a/man/shared_name.Rd
+++ b/man/shared_name.Rd
@@ -10,10 +10,10 @@ shared_name(x)
 \item{x}{a shared object as returned by \code{\link[=share]{share()}} or \code{\link[=map_shared]{map_shared()}}.}
 }
 \value{
-A character string identifying the shared object, or the empty
-string \code{""} if \code{x} is not a shared object. For a sub-list or element
-extracted from a shared list, the string carries a bracketed 1-based
-index path (e.g. \code{"/mori_abc_1[2,3]"}). \code{\link[=map_shared]{map_shared()}} accepts both
+A character string identifying the shared object, or \code{NULL}
+if \code{x} is not a shared object. For a sub-list or element extracted
+from a shared list, the string carries a bracketed 1-based index
+path (e.g. \code{"/mori_abc_1[2,3]"}). \code{\link[=map_shared]{map_shared()}} accepts both
 forms; the path-bearing form returns the addressed sub-object directly.
 The OS-level SHM region name is the prefix before \code{[} and is
 recoverable via \verb{sub("\\\[.*$", "", shared_name(x))}.

--- a/man/shared_name.Rd
+++ b/man/shared_name.Rd
@@ -10,16 +10,16 @@ shared_name(x)
 \item{x}{a shared object as returned by \code{\link[=share]{share()}} or \code{\link[=map_shared]{map_shared()}}.}
 }
 \value{
-A character string identifying the shared object, or \code{NULL}
-if \code{x} is not a shared object. For a sub-list or element extracted
-from a shared list, the string carries a bracketed 1-based index
-path (e.g. \code{"/mori_abc_1[2,3]"}). \code{\link[=map_shared]{map_shared()}} accepts both
-forms; the path-bearing form returns the addressed sub-object directly.
-The OS-level SHM region name is the prefix before \code{[} and is
+A character string identifying the shared object, or \code{NULL} if
+\code{x} is not a shared object. For a sub-list or element extracted from a
+shared list, the string carries a bracketed 1-based index path (e.g.
+\code{"/mori_abc_1[2,3]"}). \code{\link[=map_shared]{map_shared()}} accepts both forms; the
+path-qualified form returns the addressed sub-object directly. The
+underlying shared memory region name is the prefix before \code{[} and is
 recoverable via \verb{sub("\\\[.*$", "", shared_name(x))}.
 }
 \description{
-Extract the SHM region name from a shared object. This name can be
+Extract the shared memory name from a shared object. This name can be
 passed to \code{\link[=map_shared]{map_shared()}} to open the same region in another process.
 }
 \examples{

--- a/src/altrep.c
+++ b/src/altrep.c
@@ -1133,16 +1133,16 @@ static inline int32_t mori_index_of(SEXP x) {
 }
 
 SEXP mori_shm_name(SEXP x) {
-  if (!ALTREP(x)) return R_BlankScalarString;
+  if (!ALTREP(x)) return R_NilValue;
   SEXP d1 = R_altrep_data1(x);
   if (TYPEOF(d1) != EXTPTRSXP ||
       R_ExternalPtrTag(d1) != mori_owned_tag)
-    return R_BlankScalarString;
+    return R_NilValue;
 
   char buf[MORI_FORMAT_BUFLEN];
   if (mori_format_chain(R_ExternalPtrProtected(d1), mori_index_of(x),
                         buf, sizeof(buf)) != 0)
-    return R_BlankScalarString;
+    return R_NilValue;
   return Rf_mkString(buf);
 }
 

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -33,15 +33,15 @@ test_that("shared_name returns a non-empty string for shared objects", {
   expect_true(is.character(shared_name(s)))
 })
 
-test_that("shared_name returns '' for non-shared inputs", {
-  expect_identical(shared_name(1:10), "")
-  expect_identical(shared_name(NULL), "")
-  expect_identical(shared_name(list(a = 1)), "")
-  expect_identical(shared_name("a"), "")
+test_that("shared_name returns NULL for non-shared inputs", {
+  expect_null(shared_name(1:10))
+  expect_null(shared_name(NULL))
+  expect_null(shared_name(list(a = 1)))
+  expect_null(shared_name("a"))
 
   s <- share(letters)
   nm <- shared_name(s)
-  expect_identical(shared_name(nm), "")
+  expect_null(shared_name(nm))
 })
 
 test_that("map_shared returns NULL on malformed input", {
@@ -55,7 +55,7 @@ test_that("map_shared returns NULL on malformed input", {
   expect_null(map_shared(list("a")))
 })
 
-test_that("map_shared composes with shared_name sentinel without tryCatch", {
+test_that("map_shared composes with shared_name on non-shared input", {
   expect_null(map_shared(shared_name(1:10)))
 })
 
@@ -274,15 +274,15 @@ test_that("is_shared/shared_name preserved after COW materialization", {
   expect_identical(shared_name(x), nm)
 })
 
-test_that("shared_name returns '' for nesting beyond MORI_MAX_PATH", {
-  # Chain length > 64 forces mori_format_chain to overflow → "".
+test_that("shared_name returns NULL for nesting beyond MORI_MAX_PATH", {
+  # Chain length > 64 forces mori_format_chain to overflow → NULL.
   x <- 1:5
   for (i in seq_len(70)) x <- list(x)
   sx <- share(x)
   deep <- sx
   for (i in seq_len(70)) deep <- deep[[1]]
   expect_true(is_shared(deep))
-  expect_identical(shared_name(deep), "")
+  expect_null(shared_name(deep))
 
   # Same for a string leaf and an intermediate sub-list at depth.
   xs <- letters
@@ -291,7 +291,7 @@ test_that("shared_name returns '' for nesting beyond MORI_MAX_PATH", {
   deep_s <- sxs
   for (i in seq_len(70)) deep_s <- deep_s[[1]]
   expect_true(is_shared(deep_s))
-  expect_identical(shared_name(deep_s), "")
+  expect_null(shared_name(deep_s))
 
   xl <- list(leaf = 1:3)
   for (i in seq_len(70)) xl <- list(xl)
@@ -299,10 +299,10 @@ test_that("shared_name returns '' for nesting beyond MORI_MAX_PATH", {
   deep_l <- sxl
   for (i in seq_len(68)) deep_l <- deep_l[[1]]
   expect_true(is_shared(deep_l))
-  expect_identical(shared_name(deep_l), "")
+  expect_null(shared_name(deep_l))
 })
 
-test_that("shared_name returns '' for a non-mori ALTREP", {
-  # A compact-seq ALTREP has no mori_owned_tag at data1 → blank.
-  expect_identical(shared_name(1:5), "")
+test_that("shared_name returns NULL for a non-mori ALTREP", {
+  # A compact-seq ALTREP has no mori_owned_tag at data1 → NULL.
+  expect_null(shared_name(1:5))
 })


### PR DESCRIPTION
From `""` to `NULL`.

As the consumer of `shared_name()` i.e. a `map_shared()` call is typically in another process, we want to 'fail fast' here and so returning NULL facilitates handling at the point of failure rather than downstream at the `map_shared()` site.

It allows for idiomatic language such as `nm <- shared_name(x) %||% stop("not a shared object")`.