### PR TITLE
Create macOS marker before SHM region is observable

### DIFF
--- a/src/shm.c
+++ b/src/shm.c
@@ -379,6 +379,10 @@ int mori_shm_create(mori_shm *shm, size_t size) {
   }
   if (fd < 0) return MORI_ERR_NAME_COLLISION;
 
+#ifdef __APPLE__
+  mori_marker_create(shm->name);   /* register for reaping */
+#endif
+
   if (ftruncate(fd, (off_t) size) != 0)
     return mori_create_fail(fd, shm->name, errno);
 
@@ -404,10 +408,6 @@ int mori_shm_create(mori_shm *shm, size_t size) {
     madvise(addr, size, MADV_HUGEPAGE);
 #elif defined(__APPLE__)
   madvise(addr, size, MADV_WILLNEED);
-#endif
-
-#ifdef __APPLE__
-  mori_marker_create(shm->name);   /* register for reaping */
 #endif
 
   shm->addr = addr;


### PR DESCRIPTION
Follow-up to #33.

Moves `mori_marker_create()` to immediately after the `shm_open()` retry loop succeeds, before `ftruncate`/`mmap`. The marker now exists from the moment the region's name is committed, so a crash mid-create can leave at worst a benign stale marker (self-healed by reaping) rather than a region with no marker (an unreapable leak). The teardown order in `mori_shm_os_unlink` (region then marker) already had this property; this makes create symmetric.

Post-`shm_open` failure exits already route through `mori_create_fail` → `mori_shm_os_unlink` → `mori_marker_remove`, so the marker is cleaned up on a failed `ftruncate`/`mmap` with no extra code.