### PR TITLE
Unify and align examples across share API functions

### DIFF
--- a/R/share.R
+++ b/R/share.R
@@ -44,8 +44,11 @@
 #' ```
 #'
 #' @examples
-#' x <- share(rnorm(100))
+#' x <- share(1:100)
 #' sum(x)
+#'
+#' lst <- share(list(a = 1:3, b = letters))
+#' is_shared(lst)
 #'
 #' @seealso [map_shared()] to open a shared region by name,
 #'   [shared_name()] to extract the shared memory name.
@@ -73,8 +76,11 @@ share <- function(x) .Call(mori_create, x)
 #' @examples
 #' x <- share(1:100)
 #' nm <- shared_name(x)
-#' y <- map_shared(nm)
-#' sum(y)
+#' map_shared(nm)
+#'
+#' # A bracketed index path opens the addressed sub-object directly:
+#' lst <- share(list(a = 1:3, b = letters))
+#' map_shared(shared_name(lst[[2]]))
 #'
 #' @seealso [share()] to create a shared object, [shared_name()] to extract
 #'   the shared memory name.
@@ -92,9 +98,10 @@ map_shared <- function(name) .Call(mori_shm_open_and_wrap, name)
 #' @return `TRUE` or `FALSE`.
 #'
 #' @examples
-#' x <- share(rnorm(100))
+#' x <- 1:100
+#' y <- share(x)
+#' is_shared(y)
 #' is_shared(x)
-#' is_shared(rnorm(100))
 #'
 #' @export
 is_shared <- function(x) .Call(mori_is_shared, x)
@@ -115,8 +122,12 @@ is_shared <- function(x) .Call(mori_is_shared, x)
 #'   recoverable via `sub("\\[.*$", "", shared_name(x))`.
 #'
 #' @examples
-#' x <- share(rnorm(100))
+#' x <- share(1:100)
 #' shared_name(x)
+#'
+#' # A sub-object extracted from a shared list carries a bracketed index path:
+#' lst <- share(list(a = 1:3, b = letters))
+#' shared_name(lst[[2]])
 #'
 #' @seealso [map_shared()] to open a shared region by name.
 #'

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ boot_mean <- \(i, data) colMeans(data[sample(nrow(data), replace = TRUE), ])
 # Without mori — each daemon deserializes a full copy
 mirai_map(1:8, boot_mean, .args = list(data = df))[] |> system.time()
 #>    user  system elapsed 
-#>   0.709  12.272   8.631
+#>   0.618  13.114   8.370
 
 # With mori — each daemon maps the same shared memory
 mirai_map(1:8, boot_mean, .args = list(data = shared_df))[] |> system.time()
 #>    user  system elapsed 
-#>   0.002   0.004   4.991
+#>   0.002   0.003   4.780
 
 daemons(0)
 ```
@@ -111,7 +111,7 @@ reference between processes without going through serialization:
 x <- share(rnorm(1e6))
 
 shared_name(x)
-#> [1] "/mori_4d1b_1"
+#> [1] "/mori_91ee_1"
 
 # Another process — here the same one — can map the region by name
 y <- map_shared(shared_name(x))
@@ -170,9 +170,9 @@ strings are accessed lazily per element.
 ``` r
 df <- share(as.data.frame(matrix(rnorm(1e7), ncol = 100)))
 shared_name(df)        # one region for all 100 columns
-#> [1] "/mori_4d1b_3"
+#> [1] "/mori_91ee_3"
 shared_name(df[[50]])  # sub-path into the same region
-#> [1] "/mori_4d1b_3[50]"
+#> [1] "/mori_91ee_3[50]"
 ```
 
 ### Lifetime

--- a/man/is_shared.Rd
+++ b/man/is_shared.Rd
@@ -17,8 +17,9 @@ Returns \code{TRUE} if \code{x} is an ALTREP object backed by shared memory
 (created by \code{\link[=share]{share()}} or \code{\link[=map_shared]{map_shared()}}), \code{FALSE} otherwise.
 }
 \examples{
-x <- share(rnorm(100))
+x <- 1:100
+y <- share(x)
+is_shared(y)
 is_shared(x)
-is_shared(rnorm(100))
 
 }

--- a/man/map_shared.Rd
+++ b/man/map_shared.Rd
@@ -27,8 +27,11 @@ ALTREP-backed R object that reads directly from shared memory.
 \examples{
 x <- share(1:100)
 nm <- shared_name(x)
-y <- map_shared(nm)
-sum(y)
+map_shared(nm)
+
+# A bracketed index path opens the addressed sub-object directly:
+lst <- share(list(a = 1:3, b = letters))
+map_shared(shared_name(lst[[2]]))
 
 }
 \seealso{

--- a/man/share.Rd
+++ b/man/share.Rd
@@ -54,8 +54,11 @@ which deep-duplicates the object:
 }
 
 \examples{
-x <- share(rnorm(100))
+x <- share(1:100)
 sum(x)
+
+lst <- share(list(a = 1:3, b = letters))
+is_shared(lst)
 
 }
 \seealso{

--- a/man/shared_name.Rd
+++ b/man/shared_name.Rd
@@ -23,8 +23,12 @@ Extract the shared memory name from a shared object. This name can be
 passed to \code{\link[=map_shared]{map_shared()}} to open the same region in another process.
 }
 \examples{
-x <- share(rnorm(100))
+x <- share(1:100)
 shared_name(x)
+
+# A sub-object extracted from a shared list carries a bracketed index path:
+lst <- share(list(a = 1:3, b = letters))
+shared_name(lst[[2]])
 
 }
 \seealso{


### PR DESCRIPTION
Align the runnable examples across `share()`, `map_shared()`, `shared_name()`, and `is_shared()` so they share the same `1:100` root object and `list(a = 1:3, b = letters)` list case, and demonstrate the bracketed sub-object path form.